### PR TITLE
Sprint6d sprucing up app

### DIFF
--- a/src/app/api/schools/[name]/route.ts
+++ b/src/app/api/schools/[name]/route.ts
@@ -74,6 +74,8 @@ export async function GET(
     { params }: { params: Promise<{ name: string }> },
 ) {
     try {
+        const { searchParams } = new URL(req.url);
+        const year = Number(searchParams.get("year"));
         const { name } = await params;
         const searchName = name.replace(/-/g, " ");
 
@@ -100,10 +102,7 @@ export async function GET(
             .select({ total: sum(projects.numStudents) })
             .from(projects)
             .where(
-                and(
-                    eq(projects.schoolId, school.id),
-                    eq(projects.year, pastYear),
-                ),
+                and(eq(projects.schoolId, school.id), eq(projects.year, year)),
             );
 
         const teacherCount = await db
@@ -112,7 +111,7 @@ export async function GET(
             .where(
                 and(
                     eq(yearlyTeacherParticipation.schoolId, school.id),
-                    eq(yearlyTeacherParticipation.year, pastYear),
+                    eq(yearlyTeacherParticipation.year, year),
                 ),
             );
 
@@ -120,10 +119,19 @@ export async function GET(
             .select({ count: sql<number>`count(*)` })
             .from(projects)
             .where(
-                and(
-                    eq(projects.schoolId, school.id),
-                    eq(projects.year, pastYear),
-                ),
+                and(eq(projects.schoolId, school.id), eq(projects.year, year)),
+            );
+
+        const projectRows = await db
+            .select({
+                id: projects.id,
+                title: projects.title,
+                numStudents: projects.numStudents,
+                year: projects.year,
+            })
+            .from(projects)
+            .where(
+                and(eq(projects.schoolId, school.id), eq(projects.year, year)),
             );
 
         // First year would be minimum year found in a school's projects
@@ -143,6 +151,7 @@ export async function GET(
             teacherCount: teacherCount[0]?.count ?? 0,
             projectCount: projectCount[0]?.count ?? 0,
             firstYear: firstYearData[0]?.year ?? null,
+            projects: projectRows,
             // TO DO: Instructional model not in database yet
             instructionalModel: "normal",
         });

--- a/src/app/api/schools/[name]/route.ts
+++ b/src/app/api/schools/[name]/route.ts
@@ -95,8 +95,6 @@ export async function GET(
         }
 
         const school = schoolResult[0];
-        const currentYear = new Date().getFullYear();
-        const pastYear = currentYear - 1;
 
         const studentCount = await db
             .select({ total: sum(projects.numStudents) })

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -256,7 +256,7 @@ export default function GraphsPage() {
             measuredAs,
         ],
     );
-    const svgRef = useRef<SVGSVGElement | null>(null);
+    const chartRef = useRef<HTMLDivElement | null>(null);
 
     // Fetch all project data
     useEffect(() => {
@@ -674,7 +674,9 @@ export default function GraphsPage() {
                                     variant="outline"
                                     size="sm"
                                     className="flex items-center gap-2"
-                                    onClick={() => downloadSingleGraph(svgRef)}
+                                    onClick={() =>
+                                        downloadSingleGraph(chartRef)
+                                    }
                                 >
                                     <Share className="w-4 h-4" />
                                     Export
@@ -690,7 +692,7 @@ export default function GraphsPage() {
                                                 className="flex items-center gap-2"
                                                 onClick={() =>
                                                     addToCart(
-                                                        svgRef,
+                                                        chartRef,
                                                         cart,
                                                         setCart,
                                                         filterNames,
@@ -914,7 +916,7 @@ export default function GraphsPage() {
                                                 ? undefined
                                                 : groupByLabels[filters.groupBy]
                                         }
-                                        svgRef={svgRef}
+                                        chartRef={chartRef}
                                         tooltipFormatter={tooltipFormatter}
                                     />
                                 ) : (
@@ -929,7 +931,7 @@ export default function GraphsPage() {
                                                 ? undefined
                                                 : groupByLabels[filters.groupBy]
                                         }
-                                        svgRef={svgRef}
+                                        chartRef={chartRef}
                                         tooltipFormatter={tooltipFormatter}
                                     />
                                 )}

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -19,9 +19,10 @@ import {
     PlusCircle,
     Share,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import BarGraph, { type BarDataset } from "@/components/BarGraph";
+import BarGraph from "@/components/BarGraph";
+import { type ChartDataset } from "@/components/chartTypes";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import GraphFilters, {
     type Filters,
@@ -363,7 +364,7 @@ export default function GraphsPage() {
     }, [timePeriod, allProjects]);
 
     // Memoize graph dataset calculation to run only when data or filters change
-    const graphDataset: BarDataset[] = useMemo(() => {
+    const graphDataset: ChartDataset[] = useMemo(() => {
         if (!allProjects.length) return [];
 
         // Pre-calculate teacher participation years if filter is active
@@ -579,10 +580,30 @@ export default function GraphsPage() {
     const filteredProjectCount = useMemo(() => {
         return graphDataset.reduce((total, dataset) => {
             return (
-                total + dataset.data.reduce((sum, point) => sum + point.y, 0)
+                total +
+                dataset.data.reduce(
+                    (sum: number, point: { x: string | number; y: number }) =>
+                        sum + point.y,
+                    0,
+                )
             );
         }, 0);
     }, [graphDataset]);
+
+    const tooltipFormatter = useCallback(
+        (d: { x: string | number; y: number }, label: string) => {
+            const metric =
+                measuredAsLabels[filters.measuredAs] || filters.measuredAs;
+            const value =
+                filters.measuredAs === "school-return-rate"
+                    ? `${(d.y * 100).toFixed(1)}%`
+                    : Math.round(d.y).toLocaleString();
+            return filters.groupBy === "none"
+                ? `${d.x}: ${value} ${metric}`
+                : `${label} · ${d.x}: ${value}`;
+        },
+        [filters.measuredAs, filters.groupBy],
+    );
 
     // Data for filter dropdowns
     const schools = Array.from(
@@ -894,6 +915,7 @@ export default function GraphsPage() {
                                                 : groupByLabels[filters.groupBy]
                                         }
                                         svgRefCopy={svgRef}
+                                        tooltipFormatter={tooltipFormatter}
                                     />
                                 ) : (
                                     <LineGraph
@@ -908,6 +930,7 @@ export default function GraphsPage() {
                                                 : groupByLabels[filters.groupBy]
                                         }
                                         svgRefCopy={svgRef}
+                                        tooltipFormatter={tooltipFormatter}
                                     />
                                 )}
                             </div>

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -914,7 +914,7 @@ export default function GraphsPage() {
                                                 ? undefined
                                                 : groupByLabels[filters.groupBy]
                                         }
-                                        svgRefCopy={svgRef}
+                                        svgRef={svgRef}
                                         tooltipFormatter={tooltipFormatter}
                                     />
                                 ) : (
@@ -929,7 +929,7 @@ export default function GraphsPage() {
                                                 ? undefined
                                                 : groupByLabels[filters.groupBy]
                                         }
-                                        svgRefCopy={svgRef}
+                                        svgRef={svgRef}
                                         tooltipFormatter={tooltipFormatter}
                                     />
                                 )}

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -109,31 +109,29 @@ export default function SchoolProfilePage() {
             });
     }, [schoolName, router, year]);
 
-    // Fetches student data for the last 5 years
+    // Fetches student data for the last 5 years in parallel
     useEffect(() => {
         const fetchData = async () => {
-            setstudentYearData([]);
-            for (let i = 5; i >= 0; i--) {
-                try {
-                    const res = await fetch(
-                        `/api/schools/${schoolName}?year=${year - i}`,
-                    );
-                    const yearInfo = await res.json();
-
-                    const thisYear: { x: string | number; y: number } = {
-                        x: year - i,
-                        y: yearInfo.studentCount,
-                    };
-                    setstudentYearData((prev) => [thisYear, ...prev]);
-                } catch {
-                    toast.error(
-                        "Failed to load dashboard data. Please try again.",
-                    );
-                }
+            const years = Array.from({ length: 6 }, (_, i) => year - (5 - i));
+            try {
+                const results = await Promise.all(
+                    years.map((y) =>
+                        fetch(`/api/schools/${schoolName}?year=${y}`).then(
+                            (r) => r.json(),
+                        ),
+                    ),
+                );
+                const points = results.map((yearInfo, i) => ({
+                    x: years[i],
+                    y: Number(yearInfo.studentCount),
+                }));
+                setstudentYearData(points);
+            } catch {
+                toast.error("Failed to load dashboard data. Please try again.");
             }
         };
         fetchData();
-    }, [year]);
+    }, [year, schoolName]);
 
     const studentData: GraphDataset = {
         label: "Students by Year",

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -18,6 +18,7 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SchoolProfileSkeleton } from "@/components/skeletons/SchoolProfileSkeleton";
 import { MapPlacer } from "@/components/ui/mapPlacer";
 import { SchoolInfoRow } from "@/components/SchoolInfoRow";
+import YearDropdown from "@/components/YearDropdown";
 
 // interface such that data can be blank if API is loading
 type SchoolData = {
@@ -43,6 +44,7 @@ export default function SchoolProfilePage() {
 
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
     const [coordinates, setCoordinates] = useState<MapCoordinates | null>(null);
+    const [year, setYear] = useState<number | null>(null);
 
     useEffect(() => {
         fetch(`/api/schools/${schoolName}`)
@@ -76,6 +78,11 @@ export default function SchoolProfilePage() {
                 <Breadcrumbs />
                 {/* Header with school name */}
                 <h1 className="text-2xl font-bold">{schoolData.name}</h1>
+                <YearDropdown
+                    showDataIndicator={true}
+                    selectedYear={year}
+                    onYearChange={setYear}
+                />
 
                 {/* Stats cards */}
                 <div className="grid grid-cols-3 gap-8">

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -19,6 +19,10 @@ import { SchoolProfileSkeleton } from "@/components/skeletons/SchoolProfileSkele
 import { MapPlacer } from "@/components/ui/mapPlacer";
 import { SchoolInfoRow } from "@/components/SchoolInfoRow";
 import YearDropdown from "@/components/YearDropdown";
+import MultiLineGraph from "@/components/LineGraph";
+import BarGraph from "@/components/BarGraph";
+import { DataTable } from "@/components/DataTable";
+import { ColumnDef } from "@tanstack/react-table";
 
 // interface such that data can be blank if API is loading
 type SchoolData = {
@@ -28,12 +32,20 @@ type SchoolData = {
     teacherCount: string;
     projectCount: string;
     firstYear: string;
+    projects: ProjectRow[];
     instructionalModel: string;
 };
 
 type MapCoordinates = {
     latitude: number | null;
     longitude: number | null;
+};
+
+type ProjectRow = {
+    id: string;
+    title: string;
+    numStudents: number;
+    year: number;
 };
 
 export default function SchoolProfilePage() {
@@ -44,10 +56,28 @@ export default function SchoolProfilePage() {
 
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
     const [coordinates, setCoordinates] = useState<MapCoordinates | null>(null);
-    const [year, setYear] = useState<number | null>(null);
+    const [year, setYear] = useState<number | null>(2025);
+    const [projects, setProjects] = useState<ProjectRow[]>([]);
+
+    const projectColumns: ColumnDef<ProjectRow>[] = [
+        {
+            accessorKey: "title",
+            header: "Title",
+        },
+        {
+            accessorKey: "numStudents",
+            header: "Students",
+        },
+        {
+            accessorKey: "year",
+            header: "Year",
+        },
+    ];
 
     useEffect(() => {
-        fetch(`/api/schools/${schoolName}`)
+        if (!year) return;
+
+        fetch(`/api/schools/${schoolName}?year=${year}`)
             .then((response) => {
                 if (!response.ok) {
                     throw new Error(`Failed to fetch school data`);
@@ -56,6 +86,7 @@ export default function SchoolProfilePage() {
             })
             .then((data) => {
                 setSchoolData(data);
+                setProjects(data.projects);
             })
             .catch(() => {
                 toast.error(
@@ -66,7 +97,7 @@ export default function SchoolProfilePage() {
                     router.push("/schools");
                 }, 2000);
             });
-    }, [schoolName, router]);
+    }, [schoolName, router, year]);
 
     if (!schoolData) {
         return <SchoolProfileSkeleton />;
@@ -159,11 +190,10 @@ export default function SchoolProfilePage() {
                     <h2 className="text-xl font-semibold mb-4 text-foreground">
                         View and edit data
                     </h2>
-                    <div className="h-48 flex items-center justify-center bg-muted rounded">
-                        <p className="text-sm text-muted-foreground">
-                            Data table placeholder
-                        </p>
-                    </div>
+                    <DataTable
+                        columns={projectColumns}
+                        data={projects}
+                    ></DataTable>
                 </div>
             </div>
         </div>

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
@@ -22,8 +23,6 @@ import YearDropdown from "@/components/YearDropdown";
 import MultiLineGraph, { GraphDataset } from "@/components/LineGraph";
 import { DataTable } from "@/components/DataTable";
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 // interface such that data can be blank if API is loading
 type SchoolData = {
@@ -49,16 +48,9 @@ type ProjectRow = {
     year: number;
 };
 
-type chartFilters = {
-    yearStart: number;
-    yearEnd: number;
-    isProjects: boolean;
-};
-
 export default function SchoolProfilePage() {
     const params = useParams();
     const schoolName = params.name as string;
-
     const router = useRouter();
 
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
@@ -138,11 +130,7 @@ export default function SchoolProfilePage() {
         data: studentYearData,
     };
 
-    const studentChartFilters: chartFilters = {
-        yearStart: year - 5,
-        yearEnd: year,
-        isProjects: false,
-    };
+    const studentsHref = `/chart?type=line&startYear=${year - 5}&endYear=${year}&measuredAs=total-student-count&schools=${encodeURIComponent(schoolData?.name ?? "")}`;
 
     if (!schoolData) {
         return <SchoolProfileSkeleton />;
@@ -187,28 +175,19 @@ export default function SchoolProfilePage() {
                     instructionalModel={schoolData.instructionalModel}
                     firstYear={schoolData.firstYear}
                 />
-                <div className="flex flex-col m-5">
-                    <div className="flex flex-row gap-3 items-center">
+                <Link
+                    href={studentsHref}
+                    className="block rounded-lg border border-border px-6 pt-4 pb-2 hover:bg-muted/40 transition-colors"
+                >
+                    <p className="text-sm font-medium text-center mb-2">
                         Total # Students
-                        <Button
-                            onClick={() =>
-                                router.push(
-                                    `/chart?type=line&startYear=${studentChartFilters.yearStart}&endYear=${studentChartFilters.yearEnd}&measuredAs=total-student-count&schools=${schoolData.name}`,
-                                )
-                            }
-                        >
-                            <div className="flex flex-row gap-3">
-                                View More
-                                <ArrowRight></ArrowRight>
-                            </div>
-                        </Button>
-                    </div>
+                    </p>
                     <MultiLineGraph
                         datasets={[studentData]}
                         yAxisLabel={"Total # Students"}
                         xAxisLabel="Year"
                     />
-                </div>
+                </Link>
 
                 {/* Placeholders for charts */}
                 <div className="grid grid-cols-3 gap-8">

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -19,10 +19,11 @@ import { SchoolProfileSkeleton } from "@/components/skeletons/SchoolProfileSkele
 import { MapPlacer } from "@/components/ui/mapPlacer";
 import { SchoolInfoRow } from "@/components/SchoolInfoRow";
 import YearDropdown from "@/components/YearDropdown";
-import MultiLineGraph from "@/components/LineGraph";
-import BarGraph from "@/components/BarGraph";
+import MultiLineGraph, { GraphDataset } from "@/components/LineGraph";
 import { DataTable } from "@/components/DataTable";
 import { ColumnDef } from "@tanstack/react-table";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 // interface such that data can be blank if API is loading
 type SchoolData = {
@@ -48,6 +49,12 @@ type ProjectRow = {
     year: number;
 };
 
+type chartFilters = {
+    yearStart: number;
+    yearEnd: number;
+    isProjects: boolean;
+};
+
 export default function SchoolProfilePage() {
     const params = useParams();
     const schoolName = params.name as string;
@@ -56,8 +63,11 @@ export default function SchoolProfilePage() {
 
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
     const [coordinates, setCoordinates] = useState<MapCoordinates | null>(null);
-    const [year, setYear] = useState<number | null>(2025);
+    const [year, setYear] = useState<number>(2025);
     const [projects, setProjects] = useState<ProjectRow[]>([]);
+    const [studentYearData, setstudentYearData] = useState<
+        { x: string | number; y: number }[]
+    >([]);
 
     const projectColumns: ColumnDef<ProjectRow>[] = [
         {
@@ -99,6 +109,43 @@ export default function SchoolProfilePage() {
             });
     }, [schoolName, router, year]);
 
+    // Fetches student data for the last 5 years
+    useEffect(() => {
+        const fetchData = async () => {
+            setstudentYearData([]);
+            for (let i = 5; i >= 0; i--) {
+                try {
+                    const res = await fetch(
+                        `/api/schools/${schoolName}?year=${year - i}`,
+                    );
+                    const yearInfo = await res.json();
+
+                    const thisYear: { x: string | number; y: number } = {
+                        x: year - i,
+                        y: yearInfo.studentCount,
+                    };
+                    setstudentYearData((prev) => [thisYear, ...prev]);
+                } catch {
+                    toast.error(
+                        "Failed to load dashboard data. Please try again.",
+                    );
+                }
+            }
+        };
+        fetchData();
+    }, [year]);
+
+    const studentData: GraphDataset = {
+        label: "Students by Year",
+        data: studentYearData,
+    };
+
+    const studentChartFilters: chartFilters = {
+        yearStart: year - 5,
+        yearEnd: year,
+        isProjects: false,
+    };
+
     if (!schoolData) {
         return <SchoolProfileSkeleton />;
     }
@@ -112,7 +159,12 @@ export default function SchoolProfilePage() {
                 <YearDropdown
                     showDataIndicator={true}
                     selectedYear={year}
-                    onYearChange={setYear}
+                    onYearChange={(selectedYear) => {
+                        if (selectedYear !== null) {
+                            setYear(selectedYear);
+                        }
+                    }}
+                    school={schoolData.name}
                 />
 
                 {/* Stats cards */}
@@ -137,6 +189,28 @@ export default function SchoolProfilePage() {
                     instructionalModel={schoolData.instructionalModel}
                     firstYear={schoolData.firstYear}
                 />
+                <div className="flex flex-col m-5">
+                    <div className="flex flex-row gap-3 items-center">
+                        Total # Students
+                        <Button
+                            onClick={() =>
+                                router.push(
+                                    `/chart?type=line&startYear=${studentChartFilters.yearStart}&endYear=${studentChartFilters.yearEnd}&measuredAs=total-student-count&schools=${schoolData.name}`,
+                                )
+                            }
+                        >
+                            <div className="flex flex-row gap-3">
+                                View More
+                                <ArrowRight></ArrowRight>
+                            </div>
+                        </Button>
+                    </div>
+                    <MultiLineGraph
+                        datasets={[studentData]}
+                        yAxisLabel={"Total # Students"}
+                        xAxisLabel="Year"
+                    />
+                </div>
 
                 {/* Placeholders for charts */}
                 <div className="grid grid-cols-3 gap-8">
@@ -188,7 +262,7 @@ export default function SchoolProfilePage() {
                 {/* Data table placeholder */}
                 <div className="border border-border rounded-lg p-6">
                     <h2 className="text-xl font-semibold mb-4 text-foreground">
-                        View and edit data
+                        Project Data
                     </h2>
                     <DataTable
                         columns={projectColumns}

--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -20,6 +20,7 @@ import YearDropdown from "@/components/YearDropdown";
 
 export default function SchoolsPage() {
     const [schoolInfo, setSchoolInfo] = useState([]);
+    const [prevYearSchoolInfo, setPrevYearSchoolInfo] = useState([]);
     const [year, setYear] = useState<number | null>(2025);
     const [search, setSearch] = useState("");
     const [error, setError] = useState<string | null>(null);
@@ -38,6 +39,26 @@ export default function SchoolsPage() {
             })
             .then((data) => {
                 setSchoolInfo(data);
+            })
+            .catch((error) => {
+                setError(error.message || "Failed to load school data");
+            });
+    }, [year]);
+
+    useEffect(() => {
+        if (!year) return;
+
+        setError(null);
+
+        fetch(`/api/schools?year=${year - 1}`)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch school data`);
+                }
+                return response.json();
+            })
+            .then((data) => {
+                setPrevYearSchoolInfo(data);
             })
             .catch((error) => {
                 setError(error.message || "Failed to load school data");
@@ -68,6 +89,7 @@ export default function SchoolsPage() {
                     <SchoolsDataTable
                         columns={columns}
                         data={schoolInfo}
+                        prevData={prevYearSchoolInfo}
                         globalFilter={search}
                         setGlobalFilter={setSearch}
                     />

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -54,7 +54,7 @@ export default function BarGraph({
             return;
         }
 
-        const width = 1000;
+        const width = 900;
         const height = 400;
 
         const margin = {

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -16,7 +16,7 @@ type BarGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRefCopy?: React.RefObject<SVGSVGElement | null>;
+    svgRef?: React.RefObject<SVGSVGElement | null>;
     config?: ChartConfig;
     tooltipFormatter?: TooltipFormatter;
 };
@@ -26,7 +26,7 @@ export default function BarGraph({
     yAxisLabel,
     xAxisLabel,
     legendTitle,
-    svgRefCopy,
+    svgRef,
     config,
     tooltipFormatter,
 }: BarGraphProps) {
@@ -136,7 +136,7 @@ export default function BarGraph({
                 {/* Grid lines (SVG) */}
                 <svg
                     ref={(el) => {
-                        if (svgRefCopy !== undefined) svgRefCopy.current = el;
+                        if (svgRef !== undefined) svgRef.current = el;
                     }}
                     viewBox="0 0 100 100"
                     className="absolute inset-0 w-full h-full overflow-visible"

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -24,7 +24,7 @@ type BarGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRefCopy: React.RefObject<SVGSVGElement | null>;
+    svgRefCopy?: React.RefObject<SVGSVGElement | null>;
 };
 
 export default function BarGraph({
@@ -281,7 +281,9 @@ export default function BarGraph({
             return transform;
         });
 
-        svgRefCopy.current = svgRef.current;
+        if (svgRefCopy !== undefined) {
+            svgRefCopy.current = svgRef.current;
+        }
     }, [dataset]);
 
     return (

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -1,30 +1,35 @@
-/***************************************************************
- *
- *         /api/components/NewBargraph.tsx
- *
- *         Author: Chiara and Steven
- *         Date: 12/6/2025
- *
- *        Summary: bargraph component using D3
- **************************************************************/
-
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState, useMemo } from "react";
 import * as d3 from "d3";
+import {
+    ChartDataset,
+    ChartConfig,
+    ChartMargin,
+    TooltipFormatter,
+} from "./chartTypes";
 
-// Shared type for bar graph
-export type BarDataset = {
-    label: string;
-    data: { x: string | number; y: number }[];
+// Re-export for callers that use the old name
+export type { ChartDataset as BarDataset };
+
+const DEFAULT_MARGIN: ChartMargin = {
+    top: 20,
+    right: 20,
+    bottom: 100,
+    left: 60,
 };
+const DEFAULT_HEIGHT = 400;
+const DEFAULT_CORNER_RADIUS = 2;
+const DEFAULT_BAR_PADDING = 0.1;
 
 type BarGraphProps = {
-    dataset: BarDataset[];
+    dataset: ChartDataset[];
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
     svgRefCopy?: React.RefObject<SVGSVGElement | null>;
+    config?: ChartConfig;
+    tooltipFormatter?: TooltipFormatter;
 };
 
 export default function BarGraph({
@@ -33,6 +38,8 @@ export default function BarGraph({
     xAxisLabel,
     legendTitle,
     svgRefCopy,
+    config,
+    tooltipFormatter,
 }: BarGraphProps) {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -42,30 +49,51 @@ export default function BarGraph({
         null,
         undefined
     > | null>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
 
-    // Use same color scheme as LineGraph
-    //const colorScale = d3.scaleOrdinal(d3.schemeCategory10);
-    const colorScale = d3.scaleOrdinal(
-        d3.schemeCategory10.map((c) => c.toString()),
+    const margin: ChartMargin = { ...DEFAULT_MARGIN, ...config?.margin };
+    const height = config?.height ?? DEFAULT_HEIGHT;
+    const cornerRadius = config?.cornerRadius ?? DEFAULT_CORNER_RADIUS;
+    const barPadding = config?.barPadding ?? DEFAULT_BAR_PADDING;
+
+    const colorScale = useMemo(
+        () => d3.scaleOrdinal(d3.schemeCategory10.map((c) => c.toString())),
+        [],
     );
 
+    // Track container width responsively
     useEffect(() => {
-        if (!svgRef.current || !wrapperRef.current || dataset.length === 0) {
+        if (!wrapperRef.current) return;
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setContainerWidth(entry.contentRect.width);
+            }
+        });
+        observer.observe(wrapperRef.current);
+        return () => observer.disconnect();
+    }, []);
+
+    // Cleanup tooltip on unmount
+    useEffect(() => {
+        return () => {
+            tooltipRef.current?.remove();
+            tooltipRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (
+            !svgRef.current ||
+            !wrapperRef.current ||
+            dataset.length === 0 ||
+            containerWidth === 0
+        ) {
             return;
         }
 
-        const width = 900;
-        const height = 400;
-
-        const margin = {
-            top: 20,
-            right: 20,
-            bottom: 100,
-            left: 60,
-        };
-
+        const width = containerWidth;
         const svg = d3.select(svgRef.current);
-        svg.selectAll("*").remove(); // clear previous render
+        svg.selectAll("*").remove();
 
         if (!tooltipRef.current) {
             tooltipRef.current = d3
@@ -85,16 +113,17 @@ export default function BarGraph({
         }
 
         const tooltip = tooltipRef.current;
+        const formatTooltip: TooltipFormatter =
+            tooltipFormatter ?? ((d) => String(d.y));
 
-        // Flatten data to determine axis domains
         const allPoints = dataset.flatMap((d) => d.data);
-
         const xValues = Array.from(new Set(allPoints.map((d) => d.x)));
+
         const x = d3
             .scaleBand()
             .domain(xValues.map(String))
             .range([margin.left, width - margin.right])
-            .padding(0.1); // Spacing between x-axis values
+            .padding(barPadding);
 
         const y = d3
             .scaleLinear()
@@ -105,6 +134,7 @@ export default function BarGraph({
         const positionTooltip = (
             event: MouseEvent | FocusEvent,
             d: { x: string | number; y: number },
+            label: string,
         ) => {
             const wrapperRect = wrapperRef.current?.getBoundingClientRect();
             if (!wrapperRect || !tooltip) return;
@@ -123,16 +153,13 @@ export default function BarGraph({
                 clientY = mouseEvent.clientY;
             }
 
-            const wrapperX = clientX - wrapperRect.left;
-            const wrapperY = clientY - wrapperRect.top;
-
             tooltip
-                .text(String(d.y))
+                .text(formatTooltip(d, label))
                 .transition()
                 .duration(100)
                 .style("opacity", 1)
-                .style("left", `${wrapperX}px`)
-                .style("top", `${wrapperY}px`);
+                .style("left", `${clientX - wrapperRect.left}px`)
+                .style("top", `${clientY - wrapperRect.top}px`);
         };
 
         // Draw bars
@@ -144,7 +171,6 @@ export default function BarGraph({
                 .enter()
                 .append("path")
                 .attr("fill", colorScale(ds.label))
-                .attr("stroke-width", 1)
                 .style("cursor", "pointer")
                 .attr("tabindex", 0)
                 .on("mouseover focus", function (event, d) {
@@ -152,10 +178,10 @@ export default function BarGraph({
                         .transition()
                         .duration(100)
                         .attr("opacity", 0.85);
-                    positionTooltip(event, d);
+                    positionTooltip(event, d, ds.label);
                 })
                 .on("mousemove", function (event, d) {
-                    positionTooltip(event, d);
+                    positionTooltip(event, d, ds.label);
                 })
                 .on("mouseout blur", function () {
                     d3.select(this)
@@ -165,20 +191,20 @@ export default function BarGraph({
                     tooltip?.transition().duration(100).style("opacity", 0);
                 })
                 .attr("d", (d) => {
-                    const barX = (x(String(d.x)) || 0) + i * barWidth;
+                    const barX = (x(String(d.x)) ?? 0) + i * barWidth;
                     const barY = y(d.y);
-                    const barHeight = y(0) - y(d.y);
-                    const r = 2;
+                    const barH = y(0) - y(d.y);
+                    const r = cornerRadius;
                     const w = barWidth;
                     return `
-                  M${barX},${barY + r}
-                  a${r},${r} 0 0 1 ${r},${-r}
-                  h${w - 2 * r}
-                  a${r},${r} 0 0 1 ${r},${r}
-                  v${barHeight - r}
-                  h${-w}
-                  Z
-                `;
+                        M${barX},${barY + r}
+                        a${r},${r} 0 0 1 ${r},${-r}
+                        h${w - 2 * r}
+                        a${r},${r} 0 0 1 ${r},${r}
+                        v${barH - r}
+                        h${-w}
+                        Z
+                    `;
                 });
         });
 
@@ -189,7 +215,6 @@ export default function BarGraph({
             .call((g) => g.selectAll(".tick line").remove())
             .call((g) => g.select(".domain").remove());
 
-        // X-axis label (positioned above legend)
         svg.append("text")
             .attr("x", margin.left + (width - margin.left - margin.right) / 2)
             .attr("y", height - margin.bottom + 40)
@@ -211,7 +236,6 @@ export default function BarGraph({
             .call((g) => g.select(".domain").remove())
             .call((g) => g.selectAll(".tick text").attr("fill", "#555"));
 
-        // Y-axis label
         svg.append("text")
             .attr("transform", "rotate(-90)")
             .attr("x", -margin.top - (height - margin.top - margin.bottom) / 2)
@@ -220,7 +244,7 @@ export default function BarGraph({
             .attr("fill", "#555")
             .text(yAxisLabel);
 
-        // Legend at bottom
+        // Legend
         const legendGroup = svg
             .append("g")
             .attr("class", "legend")
@@ -229,7 +253,6 @@ export default function BarGraph({
                 `translate(${margin.left}, ${height - margin.bottom + 80})`,
             );
 
-        // Add legend title if provided
         if (legendTitle) {
             legendGroup
                 .append("text")
@@ -266,7 +289,6 @@ export default function BarGraph({
             .style("font-size", "12px")
             .attr("alignment-baseline", "middle");
 
-        // Position legend items, wrap to new line on overflow
         let xOffset = 0;
         let yOffset = 0;
         legendItems.attr("transform", function () {
@@ -284,16 +306,26 @@ export default function BarGraph({
         if (svgRefCopy !== undefined) {
             svgRefCopy.current = svgRef.current;
         }
-    }, [dataset]);
+    }, [
+        dataset,
+        yAxisLabel,
+        xAxisLabel,
+        legendTitle,
+        containerWidth,
+        cornerRadius,
+        barPadding,
+        colorScale,
+        tooltipFormatter,
+    ]);
 
     return (
-        <div ref={wrapperRef} style={{ position: "relative" }}>
+        <div ref={wrapperRef} style={{ position: "relative", width: "100%" }}>
             <svg
                 ref={svgRef}
-                width={900}
-                height={400}
-                style={{ overflow: "visible" }}
-            ></svg>
+                width={containerWidth}
+                height={height}
+                style={{ overflow: "visible", display: "block" }}
+            />
         </div>
     );
 }

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -1,26 +1,15 @@
 "use client";
 
-import { useRef, useEffect, useState, useMemo } from "react";
-import * as d3 from "d3";
+import { useState } from "react";
+import { scaleBand, scaleLinear, max } from "d3";
 import {
     ChartDataset,
     ChartConfig,
-    ChartMargin,
     TooltipFormatter,
+    CHART_COLORS,
 } from "./chartTypes";
 
-// Re-export for callers that use the old name
 export type { ChartDataset as BarDataset };
-
-const DEFAULT_MARGIN: ChartMargin = {
-    top: 20,
-    right: 20,
-    bottom: 100,
-    left: 60,
-};
-const DEFAULT_HEIGHT = 400;
-const DEFAULT_CORNER_RADIUS = 2;
-const DEFAULT_BAR_PADDING = 0.1;
 
 type BarGraphProps = {
     dataset: ChartDataset[];
@@ -41,291 +30,248 @@ export default function BarGraph({
     config,
     tooltipFormatter,
 }: BarGraphProps) {
-    const svgRef = useRef<SVGSVGElement | null>(null);
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const tooltipRef = useRef<d3.Selection<
-        HTMLDivElement,
-        unknown,
-        null,
-        undefined
-    > | null>(null);
-    const [containerWidth, setContainerWidth] = useState(0);
+    const [tooltip, setTooltip] = useState<{
+        x: number;
+        y: number;
+        content: string;
+    } | null>(null);
 
-    const margin: ChartMargin = { ...DEFAULT_MARGIN, ...config?.margin };
-    const height = config?.height ?? DEFAULT_HEIGHT;
-    const cornerRadius = config?.cornerRadius ?? DEFAULT_CORNER_RADIUS;
-    const barPadding = config?.barPadding ?? DEFAULT_BAR_PADDING;
+    const height = config?.height ?? 400;
+    const mTop = config?.margin?.top ?? 6;
+    const mRight = config?.margin?.right ?? 25;
+    const mBottom = config?.margin?.bottom ?? 80;
+    const mLeft = config?.margin?.left ?? 50;
+    const barPadding = config?.barPadding ?? 0.25;
+    const cornerRadius = config?.cornerRadius ?? 3;
 
-    const colorScale = useMemo(
-        () => d3.scaleOrdinal(d3.schemeCategory10.map((c) => c.toString())),
-        [],
+    const allXValues = Array.from(
+        new Set(dataset.flatMap((ds) => ds.data.map((d) => String(d.x)))),
     );
+    const maxY = max(dataset.flatMap((ds) => ds.data.map((d) => d.y))) ?? 0;
 
-    // Track container width responsively
-    useEffect(() => {
-        if (!wrapperRef.current) return;
-        const observer = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                setContainerWidth(entry.contentRect.width);
-            }
-        });
-        observer.observe(wrapperRef.current);
-        return () => observer.disconnect();
-    }, []);
+    const outerScale = scaleBand()
+        .domain(allXValues)
+        .range([0, 100])
+        .padding(barPadding);
 
-    // Cleanup tooltip on unmount
-    useEffect(() => {
-        return () => {
-            tooltipRef.current?.remove();
-            tooltipRef.current = null;
-        };
-    }, []);
+    const innerScale = scaleBand()
+        .domain(dataset.map((ds) => ds.label))
+        .range([0, outerScale.bandwidth()])
+        .padding(dataset.length > 1 ? 0.05 : 0);
 
-    useEffect(() => {
-        if (
-            !svgRef.current ||
-            !wrapperRef.current ||
-            dataset.length === 0 ||
-            containerWidth === 0
-        ) {
-            return;
-        }
+    const yScale = scaleLinear().domain([0, maxY]).range([100, 0]).nice();
 
-        const width = containerWidth;
-        const svg = d3.select(svgRef.current);
-        svg.selectAll("*").remove();
+    const formatTooltip: TooltipFormatter =
+        tooltipFormatter ?? ((d) => String(d.y));
+    const yTicks = yScale.ticks(6).filter((t) => Number.isInteger(t));
+    const hasLegend = dataset.length > 1 || !!legendTitle;
 
-        if (!tooltipRef.current) {
-            tooltipRef.current = d3
-                .select(wrapperRef.current)
-                .append("div")
-                .attr("class", "d3-tooltip")
-                .style("position", "absolute")
-                .style("opacity", 0)
-                .style("background", "black")
-                .style("color", "white")
-                .style("padding", "0.5rem")
-                .style("border-radius", "0.375rem")
-                .style("font-size", "0.875rem")
-                .style("pointer-events", "none")
-                .style("transform", "translate(-50%, -125%)")
-                .style("z-index", "1000");
-        }
-
-        const tooltip = tooltipRef.current;
-        const formatTooltip: TooltipFormatter =
-            tooltipFormatter ?? ((d) => String(d.y));
-
-        const allPoints = dataset.flatMap((d) => d.data);
-        const xValues = Array.from(new Set(allPoints.map((d) => d.x)));
-
-        const x = d3
-            .scaleBand()
-            .domain(xValues.map(String))
-            .range([margin.left, width - margin.right])
-            .padding(barPadding);
-
-        const y = d3
-            .scaleLinear()
-            .domain([0, d3.max(allPoints, (d) => d.y) || 10])
-            .nice()
-            .range([height - margin.bottom, margin.top]);
-
-        const positionTooltip = (
-            event: MouseEvent | FocusEvent,
-            d: { x: string | number; y: number },
-            label: string,
-        ) => {
-            const wrapperRect = wrapperRef.current?.getBoundingClientRect();
-            if (!wrapperRect || !tooltip) return;
-
-            let clientX: number;
-            let clientY: number;
-
-            if (event.type === "focus") {
-                const bar = event.target as SVGPathElement;
-                const barRect = bar.getBoundingClientRect();
-                clientX = barRect.left + barRect.width / 2;
-                clientY = barRect.top + barRect.height / 2;
-            } else {
-                const mouseEvent = event as MouseEvent;
-                clientX = mouseEvent.clientX;
-                clientY = mouseEvent.clientY;
-            }
-
-            tooltip
-                .text(formatTooltip(d, label))
-                .transition()
-                .duration(100)
-                .style("opacity", 1)
-                .style("left", `${clientX - wrapperRect.left}px`)
-                .style("top", `${clientY - wrapperRect.top}px`);
-        };
-
-        // Draw bars
-        const barWidth = x.bandwidth() / dataset.length;
-
-        dataset.forEach((ds, i) => {
-            svg.selectAll(`.bar-${i}`)
-                .data(ds.data)
-                .enter()
-                .append("path")
-                .attr("fill", colorScale(ds.label))
-                .style("cursor", "pointer")
-                .attr("tabindex", 0)
-                .on("mouseover focus", function (event, d) {
-                    d3.select(this)
-                        .transition()
-                        .duration(100)
-                        .attr("opacity", 0.85);
-                    positionTooltip(event, d, ds.label);
-                })
-                .on("mousemove", function (event, d) {
-                    positionTooltip(event, d, ds.label);
-                })
-                .on("mouseout blur", function () {
-                    d3.select(this)
-                        .transition()
-                        .duration(100)
-                        .attr("opacity", 1);
-                    tooltip?.transition().duration(100).style("opacity", 0);
-                })
-                .attr("d", (d) => {
-                    const barX = (x(String(d.x)) ?? 0) + i * barWidth;
-                    const barY = y(d.y);
-                    const barH = y(0) - y(d.y);
-                    const r = cornerRadius;
-                    const w = barWidth;
-                    return `
-                        M${barX},${barY + r}
-                        a${r},${r} 0 0 1 ${r},${-r}
-                        h${w - 2 * r}
-                        a${r},${r} 0 0 1 ${r},${r}
-                        v${barH - r}
-                        h${-w}
-                        Z
-                    `;
-                });
-        });
-
-        // X-axis
-        svg.append("g")
-            .attr("transform", `translate(0, ${height - margin.bottom})`)
-            .call(d3.axisBottom(x))
-            .call((g) => g.selectAll(".tick line").remove())
-            .call((g) => g.select(".domain").remove());
-
-        svg.append("text")
-            .attr("x", margin.left + (width - margin.left - margin.right) / 2)
-            .attr("y", height - margin.bottom + 40)
-            .attr("text-anchor", "middle")
-            .attr("fill", "#555")
-            .text(xAxisLabel);
-
-        // Y-axis
-        const yTicks = y.ticks().filter((t) => Number.isInteger(t));
-        svg.append("g")
-            .attr("transform", `translate(${margin.left},0)`)
-            .call(
-                d3
-                    .axisLeft(y)
-                    .tickValues(yTicks)
-                    .tickSize(-width + margin.left + margin.right),
-            )
-            .call((g) => g.selectAll(".tick line").attr("stroke", "#ccc"))
-            .call((g) => g.select(".domain").remove())
-            .call((g) => g.selectAll(".tick text").attr("fill", "#555"));
-
-        svg.append("text")
-            .attr("transform", "rotate(-90)")
-            .attr("x", -margin.top - (height - margin.top - margin.bottom) / 2)
-            .attr("y", 15)
-            .attr("text-anchor", "middle")
-            .attr("fill", "#555")
-            .text(yAxisLabel);
-
-        // Legend
-        const legendGroup = svg
-            .append("g")
-            .attr("class", "legend")
-            .attr(
-                "transform",
-                `translate(${margin.left}, ${height - margin.bottom + 80})`,
-            );
-
-        if (legendTitle) {
-            legendGroup
-                .append("text")
-                .attr("x", 0)
-                .attr("y", -10)
-                .text(legendTitle)
-                .style("font-size", "14px")
-                .style("font-weight", "600")
-                .attr("fill", "currentColor");
-        }
-
-        const legendWidth = width - margin.left - margin.right;
-        const itemMargin = 10;
-        const rowHeight = 20;
-
-        const legendItems = legendGroup
-            .selectAll("g.legend-item")
-            .data(dataset)
-            .enter()
-            .append("g")
-            .attr("class", "legend-item");
-
-        legendItems
-            .append("rect")
-            .attr("width", 12)
-            .attr("height", 12)
-            .attr("fill", (d) => colorScale(d.label));
-
-        legendItems
-            .append("text")
-            .attr("x", 16)
-            .attr("y", 10)
-            .text((d) => d.label)
-            .style("font-size", "12px")
-            .attr("alignment-baseline", "middle");
-
-        let xOffset = 0;
-        let yOffset = 0;
-        legendItems.attr("transform", function () {
-            const itemWidth =
-                (this as SVGGElement).getBBox().width + itemMargin;
-            if (xOffset + itemWidth > legendWidth) {
-                xOffset = 0;
-                yOffset += rowHeight;
-            }
-            const transform = `translate(${xOffset}, ${yOffset})`;
-            xOffset += itemWidth;
-            return transform;
-        });
-
-        if (svgRefCopy !== undefined) {
-            svgRefCopy.current = svgRef.current;
-        }
-    }, [
-        dataset,
-        yAxisLabel,
-        xAxisLabel,
-        legendTitle,
-        containerWidth,
-        cornerRadius,
-        barPadding,
-        colorScale,
-        tooltipFormatter,
-    ]);
+    const chartTop = mTop;
+    const chartBottom = height - mBottom;
+    const chartHeight = chartBottom - chartTop;
 
     return (
-        <div ref={wrapperRef} style={{ position: "relative", width: "100%" }}>
-            <svg
-                ref={svgRef}
-                width={containerWidth}
-                height={height}
-                style={{ overflow: "visible", display: "block" }}
-            />
+        <div className="relative w-full select-none" style={{ height }}>
+            {/* Tooltip */}
+            {tooltip && (
+                <div
+                    className="fixed z-50 bg-popover text-popover-foreground border border-border shadow-sm text-xs px-2 py-1 rounded-md pointer-events-none whitespace-nowrap"
+                    style={{
+                        left: tooltip.x,
+                        top: tooltip.y - 8,
+                        transform: "translate(-50%, -100%)",
+                    }}
+                >
+                    {tooltip.content}
+                </div>
+            )}
+
+            {/* Y-axis: rotated label strip + tick values */}
+            <div
+                className="absolute overflow-visible"
+                style={{
+                    top: chartTop,
+                    left: 0,
+                    width: mLeft,
+                    height: chartHeight,
+                }}
+            >
+                {/* Rotated axis title — occupies leftmost 16px */}
+                <div
+                    className="absolute inset-y-0 flex items-center justify-center"
+                    style={{ left: 0, width: 16 }}
+                >
+                    <span
+                        className="text-xs text-muted-foreground whitespace-nowrap pointer-events-none"
+                        style={{
+                            writingMode: "vertical-rl",
+                            transform: "rotate(180deg)",
+                        }}
+                    >
+                        {yAxisLabel}
+                    </span>
+                </div>
+                {/* Tick values — confined to right portion, away from label */}
+                {yTicks.map((value, i) => (
+                    <div
+                        key={i}
+                        style={{ top: `${yScale(value)}%`, left: 24, right: 0 }}
+                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-2"
+                    >
+                        {value.toLocaleString()}
+                    </div>
+                ))}
+            </div>
+
+            {/* Chart area */}
+            <div
+                className="absolute overflow-visible"
+                style={{
+                    top: chartTop,
+                    left: mLeft,
+                    right: mRight,
+                    height: chartHeight,
+                }}
+            >
+                {/* Grid lines (SVG) */}
+                <svg
+                    ref={(el) => {
+                        if (svgRefCopy !== undefined) svgRefCopy.current = el;
+                    }}
+                    viewBox="0 0 100 100"
+                    className="absolute inset-0 w-full h-full overflow-visible"
+                    preserveAspectRatio="none"
+                >
+                    {yTicks.map((value, i) => (
+                        <g
+                            key={i}
+                            transform={`translate(0,${yScale(value)})`}
+                            className="text-border"
+                        >
+                            <line
+                                x1={0}
+                                x2={100}
+                                stroke="currentColor"
+                                strokeDasharray="6,5"
+                                strokeWidth={0.5}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                    ))}
+                </svg>
+
+                {/* Bars */}
+                {dataset.map((ds, si) =>
+                    ds.data.map((point, pi) => {
+                        const xKey = String(point.x);
+                        const left =
+                            (outerScale(xKey) ?? 0) +
+                            (innerScale(ds.label) ?? 0);
+                        const width = innerScale.bandwidth();
+                        const barH = Math.max(0, yScale(0) - yScale(point.y));
+                        const content = formatTooltip(point, ds.label);
+                        return (
+                            <div
+                                key={`${si}-${pi}`}
+                                className="absolute bottom-0"
+                                style={{
+                                    left: `${left}%`,
+                                    width: `${width}%`,
+                                    height: `${barH}%`,
+                                    backgroundColor:
+                                        CHART_COLORS[si % CHART_COLORS.length],
+                                    borderRadius: `${cornerRadius}px ${cornerRadius}px 0 0`,
+                                    cursor: "pointer",
+                                }}
+                                onMouseEnter={(e) =>
+                                    setTooltip({
+                                        x: e.clientX,
+                                        y: e.clientY,
+                                        content,
+                                    })
+                                }
+                                onMouseMove={(e) =>
+                                    setTooltip({
+                                        x: e.clientX,
+                                        y: e.clientY,
+                                        content,
+                                    })
+                                }
+                                onMouseLeave={() => setTooltip(null)}
+                            />
+                        );
+                    }),
+                )}
+            </div>
+
+            {/* X-axis tick labels — explicitly below chart area */}
+            <div
+                className="absolute overflow-visible"
+                style={{ top: chartBottom + 6, left: mLeft, right: mRight }}
+            >
+                {allXValues.map((xVal, i) => {
+                    const xPos =
+                        (outerScale(xVal) ?? 0) + outerScale.bandwidth() / 2;
+                    return (
+                        <div
+                            key={i}
+                            className="absolute overflow-visible text-muted-foreground"
+                            style={{
+                                left: `${xPos}%`,
+                                transform: "translateX(-50%)",
+                            }}
+                        >
+                            <span className="text-xs whitespace-nowrap">
+                                {xVal}
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* X-axis title */}
+            <div
+                className="absolute text-xs text-muted-foreground text-center"
+                style={{
+                    top: chartBottom + 28,
+                    left: mLeft,
+                    right: mRight,
+                }}
+            >
+                {xAxisLabel}
+            </div>
+
+            {/* Legend */}
+            {hasLegend && (
+                <div
+                    className="absolute flex flex-wrap items-center gap-x-4 gap-y-1"
+                    style={{
+                        top: chartBottom + 50,
+                        left: mLeft,
+                        right: mRight,
+                    }}
+                >
+                    {legendTitle && (
+                        <span className="text-xs font-semibold text-foreground w-full">
+                            {legendTitle}
+                        </span>
+                    )}
+                    {dataset.map((ds, i) => (
+                        <div key={i} className="flex items-center gap-1.5">
+                            <div
+                                className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                                style={{
+                                    backgroundColor:
+                                        CHART_COLORS[i % CHART_COLORS.length],
+                                }}
+                            />
+                            <span className="text-xs text-muted-foreground">
+                                {ds.label}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -16,7 +16,7 @@ type BarGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRef?: React.RefObject<SVGSVGElement | null>;
+    chartRef?: React.RefObject<HTMLDivElement | null>;
     config?: ChartConfig;
     tooltipFormatter?: TooltipFormatter;
 };
@@ -26,7 +26,7 @@ export default function BarGraph({
     yAxisLabel,
     xAxisLabel,
     legendTitle,
-    svgRef,
+    chartRef,
     config,
     tooltipFormatter,
 }: BarGraphProps) {
@@ -71,7 +71,11 @@ export default function BarGraph({
     const chartHeight = chartBottom - chartTop;
 
     return (
-        <div className="relative w-full select-none" style={{ height }}>
+        <div
+            ref={chartRef}
+            className="relative w-full select-none"
+            style={{ height }}
+        >
             {/* Tooltip */}
             {tooltip && (
                 <div
@@ -98,15 +102,12 @@ export default function BarGraph({
             >
                 {/* Rotated axis title — occupies leftmost 16px */}
                 <div
-                    className="absolute inset-y-0 flex items-center justify-center"
+                    className="absolute inset-y-0 flex items-center justify-center overflow-visible"
                     style={{ left: 0, width: 16 }}
                 >
                     <span
                         className="text-xs text-muted-foreground whitespace-nowrap pointer-events-none"
-                        style={{
-                            writingMode: "vertical-rl",
-                            transform: "rotate(180deg)",
-                        }}
+                        style={{ transform: "rotate(-90deg)" }}
                     >
                         {yAxisLabel}
                     </span>
@@ -123,7 +124,7 @@ export default function BarGraph({
                 ))}
             </div>
 
-            {/* Chart area */}
+            {/* Chart area — single SVG so bars are captured by svgRef for export */}
             <div
                 className="absolute overflow-visible"
                 style={{
@@ -133,15 +134,12 @@ export default function BarGraph({
                     height: chartHeight,
                 }}
             >
-                {/* Grid lines (SVG) */}
                 <svg
-                    ref={(el) => {
-                        if (svgRef !== undefined) svgRef.current = el;
-                    }}
                     viewBox="0 0 100 100"
-                    className="absolute inset-0 w-full h-full overflow-visible"
+                    className="w-full h-full overflow-visible"
                     preserveAspectRatio="none"
                 >
+                    {/* Grid lines */}
                     {yTicks.map((value, i) => (
                         <g
                             key={i}
@@ -158,50 +156,53 @@ export default function BarGraph({
                             />
                         </g>
                     ))}
-                </svg>
 
-                {/* Bars */}
-                {dataset.map((ds, si) =>
-                    ds.data.map((point, pi) => {
-                        const xKey = String(point.x);
-                        const left =
-                            (outerScale(xKey) ?? 0) +
-                            (innerScale(ds.label) ?? 0);
-                        const width = innerScale.bandwidth();
-                        const barH = Math.max(0, yScale(0) - yScale(point.y));
-                        const content = formatTooltip(point, ds.label);
-                        return (
-                            <div
-                                key={`${si}-${pi}`}
-                                className="absolute bottom-0"
-                                style={{
-                                    left: `${left}%`,
-                                    width: `${width}%`,
-                                    height: `${barH}%`,
-                                    backgroundColor:
-                                        CHART_COLORS[si % CHART_COLORS.length],
-                                    borderRadius: `${cornerRadius}px ${cornerRadius}px 0 0`,
-                                    cursor: "pointer",
-                                }}
-                                onMouseEnter={(e) =>
-                                    setTooltip({
-                                        x: e.clientX,
-                                        y: e.clientY,
-                                        content,
-                                    })
-                                }
-                                onMouseMove={(e) =>
-                                    setTooltip({
-                                        x: e.clientX,
-                                        y: e.clientY,
-                                        content,
-                                    })
-                                }
-                                onMouseLeave={() => setTooltip(null)}
-                            />
-                        );
-                    }),
-                )}
+                    {/* Bars */}
+                    {dataset.map((ds, si) =>
+                        ds.data.map((point, pi) => {
+                            const xKey = String(point.x);
+                            const x =
+                                (outerScale(xKey) ?? 0) +
+                                (innerScale(ds.label) ?? 0);
+                            const w = innerScale.bandwidth();
+                            const barH = Math.max(
+                                0,
+                                yScale(0) - yScale(point.y),
+                            );
+                            const y = yScale(point.y);
+                            const content = formatTooltip(point, ds.label);
+                            return (
+                                <rect
+                                    key={`${si}-${pi}`}
+                                    x={x}
+                                    y={y}
+                                    width={w}
+                                    height={barH}
+                                    rx={Math.min(cornerRadius * 0.15, w / 2)}
+                                    fill={
+                                        CHART_COLORS[si % CHART_COLORS.length]
+                                    }
+                                    style={{ cursor: "pointer" }}
+                                    onMouseEnter={(e) =>
+                                        setTooltip({
+                                            x: e.clientX,
+                                            y: e.clientY,
+                                            content,
+                                        })
+                                    }
+                                    onMouseMove={(e) =>
+                                        setTooltip({
+                                            x: e.clientX,
+                                            y: e.clientY,
+                                            content,
+                                        })
+                                    }
+                                    onMouseLeave={() => setTooltip(null)}
+                                />
+                            );
+                        }),
+                    )}
+                </svg>
             </div>
 
             {/* X-axis tick labels — explicitly below chart area */}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,7 +16,6 @@ import { toast } from "sonner";
 import YearDropdown from "@/components/YearDropdown";
 import MultiLineGraph from "./LineGraph";
 import { GraphDataset } from "./LineGraph";
-import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 
 type Stats = {
@@ -63,9 +62,12 @@ export default function Dashboard() {
         { x: string | number; y: number }[]
     >([]);
 
+    /*
+     * Fetches data for the chart with total # of projects
+     */
     useEffect(() => {
         const fetchData = async () => {
-            setschoolYearData([]);
+            setprojectsYearData([]);
             for (let i = 5; i >= 0; i--) {
                 try {
                     const res = await fetch(
@@ -93,9 +95,17 @@ export default function Dashboard() {
         data: projectsyearData,
     };
 
+    const schoolData: GraphDataset = {
+        label: "Schools by Year",
+        data: schoolyearData,
+    };
+
+    /*
+     * Fetches data for the chart with total # of schools
+     */
     useEffect(() => {
         const fetchData = async () => {
-            setprojectsYearData([]);
+            setschoolYearData([]);
             for (let i = 5; i >= 0; i--) {
                 try {
                     const res = await fetch(
@@ -132,6 +142,14 @@ export default function Dashboard() {
         isProjects: false,
     };
 
+    /**
+     * linkToGraph
+     * Routes the user to the page corresponding to a chart with the filters
+     * passed in
+     * @param filters The chart filters that are used to produce a link to a
+     *                a chart on the actual charts page
+     * returns: none
+     */
     function linkToGraph(filters: chartFilters) {
         if (filters.isProjects) {
             router.push(
@@ -145,29 +163,26 @@ export default function Dashboard() {
         );
     }
 
-    const schoolData: GraphDataset = {
-        label: "Schools by Year",
-        data: schoolyearData,
-    };
-
     return (
         <div className="flex flex-col gap-8 w-full px-6 py-10">
-            <h1 className="text-2xl font-semibold">Overview Dashboard</h1>
-            <div className="">
-                <YearDropdown
-                    showDataIndicator={true}
-                    selectedYear={year}
-                    onYearChange={(selectedYear) => {
-                        if (selectedYear !== null) {
-                            setYear(selectedYear);
-                        }
-                    }}
-                />
+            <div className="flex flex-row gap-5">
+                <h1 className="text-2xl font-semibold">Overview Dashboard</h1>
+                <div className="">
+                    <YearDropdown
+                        showDataIndicator={true}
+                        selectedYear={year}
+                        onYearChange={(selectedYear) => {
+                            if (selectedYear !== null) {
+                                setYear(selectedYear);
+                            }
+                        }}
+                    />
+                </div>
             </div>
 
             {stats ? (
                 <div className="">
-                    <div className="grid grid-cols-3 gap-5">
+                    <div className="grid grid-cols-4 gap-5">
                         <StatCard
                             label="Total # Projects"
                             value={stats.totals.total_projects}
@@ -185,9 +200,8 @@ export default function Dashboard() {
                             value={stats.totals.total_schools}
                         />
                         {/* TODO: Once we store type of school, make this correct */}
-                        <StatCard label="% Highschool" value={12} />
                     </div>
-                    <div className="flex flex-col m-5">
+                    <div className="flex flex-col m-5 items-center justify-center rounded-lg border py-6 border-border">
                         Total # Projects
                         <button
                             onClick={() => linkToGraph(projectChartFilters)}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import YearDropdown from "@/components/YearDropdown";
 import MultiLineGraph from "./LineGraph";
-import { GraphDataset } from "./LineGraph";
+import type { GraphDataset } from "./LineGraph";
 import { useRouter } from "next/navigation";
 
 type Stats = {
@@ -63,28 +63,32 @@ export default function Dashboard() {
     >([]);
 
     /*
-     * Fetches data for the chart with total # of projects
+     * Fetches data for both charts in parallel across all years.
+     * Uses Promise.all so all years load at once before updating state.
      */
     useEffect(() => {
         const fetchData = async () => {
-            setprojectsYearData([]);
-            for (let i = 5; i >= 0; i--) {
-                try {
-                    const res = await fetch(
-                        `/api/yearly-totals?year=${year - i}`,
-                    );
-                    const yearInfo = await res.json();
-
-                    const thisYear: { x: string | number; y: number } = {
-                        x: year - i,
-                        y: yearInfo.yearlyStats.totals.total_projects,
-                    };
-                    setprojectsYearData((prev) => [thisYear, ...prev]);
-                } catch {
-                    toast.error(
-                        "Failed to load dashboard data. Please try again.",
-                    );
-                }
+            const years = Array.from({ length: 6 }, (_, i) => year - (5 - i));
+            try {
+                const results = await Promise.all(
+                    years.map((y) =>
+                        fetch(`/api/yearly-totals?year=${y}`).then((r) =>
+                            r.json(),
+                        ),
+                    ),
+                );
+                const projectsPoints = results.map((yearInfo, i) => ({
+                    x: years[i],
+                    y: yearInfo.yearlyStats.totals.total_projects as number,
+                }));
+                const schoolsPoints = results.map((yearInfo, i) => ({
+                    x: years[i],
+                    y: yearInfo.yearlyStats.totals.total_schools as number,
+                }));
+                setprojectsYearData(projectsPoints);
+                setschoolYearData(schoolsPoints);
+            } catch {
+                toast.error("Failed to load dashboard data. Please try again.");
             }
         };
         fetchData();
@@ -99,34 +103,6 @@ export default function Dashboard() {
         label: "Schools by Year",
         data: schoolyearData,
     };
-
-    /*
-     * Fetches data for the chart with total # of schools
-     */
-    useEffect(() => {
-        const fetchData = async () => {
-            setschoolYearData([]);
-            for (let i = 5; i >= 0; i--) {
-                try {
-                    const res = await fetch(
-                        `/api/yearly-totals?year=${year - i}`,
-                    );
-                    const yearInfo = await res.json();
-
-                    const thisYear: { x: string | number; y: number } = {
-                        x: year - i,
-                        y: yearInfo.yearlyStats.totals.total_schools,
-                    };
-                    setschoolYearData((prev) => [thisYear, ...prev]);
-                } catch {
-                    toast.error(
-                        "Failed to load dashboard data. Please try again.",
-                    );
-                }
-            }
-        };
-        fetchData();
-    }, [year]);
 
     const router = useRouter();
 
@@ -201,9 +177,10 @@ export default function Dashboard() {
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                     </div>
-                    <div className="flex flex-col my-5 items-center justify-center rounded-lg border py-6 border-border">
-                        Total # Projects
+                    <div className="flex flex-col my-5 rounded-lg border py-6 border-border">
+                        <p className="text-center">Total # Projects</p>
                         <button
+                            className="w-full block"
                             onClick={() => linkToGraph(projectChartFilters)}
                         >
                             <MultiLineGraph
@@ -212,8 +189,11 @@ export default function Dashboard() {
                                 xAxisLabel="Year"
                             />
                         </button>
-                        Total # Schools
-                        <button onClick={() => linkToGraph(schoolChartFilters)}>
+                        <p className="text-center">Total # Schools</p>
+                        <button
+                            className="w-full block"
+                            onClick={() => linkToGraph(schoolChartFilters)}
+                        >
                             <MultiLineGraph
                                 datasets={[schoolData]}
                                 yAxisLabel={"Total # Schools"}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -201,7 +201,7 @@ export default function Dashboard() {
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                     </div>
-                    <div className="flex flex-col m-5 items-center justify-center rounded-lg border py-6 border-border">
+                    <div className="flex flex-col my-5 items-center justify-center rounded-lg border py-6 border-border">
                         Total # Projects
                         <button
                             onClick={() => linkToGraph(projectChartFilters)}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,6 +14,8 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import YearDropdown from "@/components/YearDropdown";
+import MultiLineGraph from "./LineGraph";
+import { GraphDataset } from "./LineGraph";
 
 type Stats = {
     totals: {
@@ -46,6 +48,70 @@ export default function Dashboard() {
 
         fetchStats(year);
     }, [year]);
+    const [projectsyearData, setprojectsYearData] = useState<
+        { x: string | number; y: number }[]
+    >([]);
+    const [schoolyearData, setschoolYearData] = useState<
+        { x: string | number; y: number }[]
+    >([]);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            for (let i = 5; i >= 0; i--) {
+                try {
+                    const res = await fetch(
+                        `/api/yearly-totals?year=${year - i}`,
+                    );
+                    const yearInfo = await res.json();
+
+                    const thisYear: { x: string | number; y: number } = {
+                        x: year - i,
+                        y: yearInfo.yearlyStats.totals.total_projects,
+                    };
+                    setprojectsYearData((prev) => [thisYear, ...prev]);
+                } catch {
+                    toast.error(
+                        "Failed to load dashboard data. Please try again.",
+                    );
+                }
+            }
+        };
+        fetchData();
+    }, [year]);
+
+    const projectsData: GraphDataset = {
+        label: "Projects by Year",
+        data: projectsyearData,
+    };
+
+    useEffect(() => {
+        const fetchData = async () => {
+            for (let i = 5; i >= 0; i--) {
+                try {
+                    const res = await fetch(
+                        `/api/yearly-totals?year=${year - i}`,
+                    );
+                    const yearInfo = await res.json();
+
+                    const thisYear: { x: string | number; y: number } = {
+                        x: year - i,
+                        y: yearInfo.yearlyStats.totals.total_schools,
+                    };
+                    setschoolYearData((prev) => [thisYear, ...prev]);
+                } catch {
+                    toast.error(
+                        "Failed to load dashboard data. Please try again.",
+                    );
+                }
+            }
+        };
+        fetchData();
+    }, [year]);
+
+    const schoolData: GraphDataset = {
+        label: "Schools by Year",
+        data: schoolyearData,
+    };
 
     return (
         <div className="flex flex-col gap-8 w-full px-6 py-10">
@@ -83,6 +149,16 @@ export default function Dashboard() {
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                         <StatCard label="% Highschool" value={12} />
+                        <MultiLineGraph
+                            datasets={[projectsData]}
+                            yAxisLabel={"Total # Projects"}
+                            xAxisLabel="Year"
+                        />
+                        <MultiLineGraph
+                            datasets={[schoolData]}
+                            yAxisLabel={"Total # Schools"}
+                            xAxisLabel="Year"
+                        />
                     </div>
                 </div>
             ) : null}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,6 +16,8 @@ import { toast } from "sonner";
 import YearDropdown from "@/components/YearDropdown";
 import MultiLineGraph from "./LineGraph";
 import { GraphDataset } from "./LineGraph";
+import { Button } from "./ui/button";
+import { useRouter } from "next/navigation";
 
 type Stats = {
     totals: {
@@ -26,6 +28,12 @@ type Stats = {
         total_cities: number;
     };
     year: number;
+};
+
+type chartFilters = {
+    yearStart: number;
+    yearEnd: number;
+    isProjects: boolean;
 };
 
 export default function Dashboard() {
@@ -57,6 +65,7 @@ export default function Dashboard() {
 
     useEffect(() => {
         const fetchData = async () => {
+            setschoolYearData([]);
             for (let i = 5; i >= 0; i--) {
                 try {
                     const res = await fetch(
@@ -86,6 +95,7 @@ export default function Dashboard() {
 
     useEffect(() => {
         const fetchData = async () => {
+            setprojectsYearData([]);
             for (let i = 5; i >= 0; i--) {
                 try {
                     const res = await fetch(
@@ -107,6 +117,33 @@ export default function Dashboard() {
         };
         fetchData();
     }, [year]);
+
+    const router = useRouter();
+
+    const projectChartFilters = {
+        yearStart: year - 5,
+        yearEnd: year,
+        isProjects: true,
+    };
+
+    const schoolChartFilters = {
+        yearStart: year - 5,
+        yearEnd: year,
+        isProjects: false,
+    };
+
+    function linkToGraph(filters: chartFilters) {
+        if (filters.isProjects) {
+            router.push(
+                `/chart?type=line&startYear=${filters.yearStart}&endYear=${filters.yearEnd}&measuredAs=total-project-count`,
+            );
+            return;
+        }
+
+        router.push(
+            `/chart?type=line&startYear=${filters.yearStart}&endYear=${filters.yearEnd}`,
+        );
+    }
 
     const schoolData: GraphDataset = {
         label: "Schools by Year",
@@ -149,16 +186,26 @@ export default function Dashboard() {
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                         <StatCard label="% Highschool" value={12} />
-                        <MultiLineGraph
-                            datasets={[projectsData]}
-                            yAxisLabel={"Total # Projects"}
-                            xAxisLabel="Year"
-                        />
-                        <MultiLineGraph
-                            datasets={[schoolData]}
-                            yAxisLabel={"Total # Schools"}
-                            xAxisLabel="Year"
-                        />
+                    </div>
+                    <div className="flex flex-col m-5">
+                        Total # Projects
+                        <button
+                            onClick={() => linkToGraph(projectChartFilters)}
+                        >
+                            <MultiLineGraph
+                                datasets={[projectsData]}
+                                yAxisLabel={"Total # Projects"}
+                                xAxisLabel="Year"
+                            />
+                        </button>
+                        Total # Schools
+                        <button onClick={() => linkToGraph(schoolChartFilters)}>
+                            <MultiLineGraph
+                                datasets={[schoolData]}
+                                yAxisLabel={"Total # Schools"}
+                                xAxisLabel="Year"
+                            />
+                        </button>
                     </div>
                 </div>
             ) : null}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 import YearDropdown from "@/components/YearDropdown";
 import MultiLineGraph from "./LineGraph";
 import type { GraphDataset } from "./LineGraph";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 type Stats = {
     totals: {
@@ -27,12 +27,6 @@ type Stats = {
         total_cities: number;
     };
     year: number;
-};
-
-type chartFilters = {
-    yearStart: number;
-    yearEnd: number;
-    isProjects: boolean;
 };
 
 export default function Dashboard() {
@@ -104,40 +98,8 @@ export default function Dashboard() {
         data: schoolyearData,
     };
 
-    const router = useRouter();
-
-    const projectChartFilters = {
-        yearStart: year - 5,
-        yearEnd: year,
-        isProjects: true,
-    };
-
-    const schoolChartFilters = {
-        yearStart: year - 5,
-        yearEnd: year,
-        isProjects: false,
-    };
-
-    /**
-     * linkToGraph
-     * Routes the user to the page corresponding to a chart with the filters
-     * passed in
-     * @param filters The chart filters that are used to produce a link to a
-     *                a chart on the actual charts page
-     * returns: none
-     */
-    function linkToGraph(filters: chartFilters) {
-        if (filters.isProjects) {
-            router.push(
-                `/chart?type=line&startYear=${filters.yearStart}&endYear=${filters.yearEnd}&measuredAs=total-project-count`,
-            );
-            return;
-        }
-
-        router.push(
-            `/chart?type=line&startYear=${filters.yearStart}&endYear=${filters.yearEnd}`,
-        );
-    }
+    const projectsHref = `/chart?type=line&startYear=${year - 5}&endYear=${year}&measuredAs=total-project-count`;
+    const schoolsHref = `/chart?type=line&startYear=${year - 5}&endYear=${year}`;
 
     return (
         <div className="flex flex-col gap-8 w-full px-6 py-10">
@@ -177,29 +139,33 @@ export default function Dashboard() {
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                     </div>
-                    <div className="flex flex-col my-5 rounded-lg border py-6 border-border">
-                        <p className="text-center">Total # Projects</p>
-                        <button
-                            className="w-full block"
-                            onClick={() => linkToGraph(projectChartFilters)}
+                    <div className="flex flex-col my-5 rounded-lg border border-border divide-y divide-border">
+                        <Link
+                            href={projectsHref}
+                            className="block px-6 pt-4 pb-2 hover:bg-muted/40 transition-colors"
                         >
+                            <p className="text-sm font-medium text-center mb-2">
+                                Total # Projects
+                            </p>
                             <MultiLineGraph
                                 datasets={[projectsData]}
                                 yAxisLabel={"Total # Projects"}
                                 xAxisLabel="Year"
                             />
-                        </button>
-                        <p className="text-center">Total # Schools</p>
-                        <button
-                            className="w-full block"
-                            onClick={() => linkToGraph(schoolChartFilters)}
+                        </Link>
+                        <Link
+                            href={schoolsHref}
+                            className="block px-6 pt-4 pb-2 hover:bg-muted/40 transition-colors"
                         >
+                            <p className="text-sm font-medium text-center mb-2">
+                                Total # Schools
+                            </p>
                             <MultiLineGraph
                                 datasets={[schoolData]}
                                 yAxisLabel={"Total # Schools"}
                                 xAxisLabel="Year"
                             />
-                        </button>
+                        </Link>
                     </div>
                 </div>
             ) : null}

--- a/src/components/DataTableSchools.tsx
+++ b/src/components/DataTableSchools.tsx
@@ -88,7 +88,6 @@ export function SchoolsDataTable<TData, TValue>({
         const prevRow = prevData[rowIndex] as Record<string, number>;
 
         if (!prevRow) return <></>;
-        const colIndex: number = cell.column.getIndex();
         const prevYearValue: number = prevRow[cell.column.id] ?? 0;
         const diff = cell.getValue() - prevYearValue;
 

--- a/src/components/DataTableSchools.tsx
+++ b/src/components/DataTableSchools.tsx
@@ -35,7 +35,6 @@ import {
 } from "@/components/ui/table";
 
 import Link from "next/link";
-import { Arrow } from "@radix-ui/react-popover";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
@@ -69,6 +68,13 @@ export function SchoolsDataTable<TData, TValue>({
         },
     });
 
+    /**
+     * yoyChange
+     * Calculates the yoy change for applicable fields of the data table
+     * @param cell The cell of the table to calculate year over year change for
+     * returns: A lucide react icon, either up arrow, down arrow, or dash, and a
+     *          number corresponding to the percent change
+     */
     function yoyChange(cell: Cell<TData, number>, row: Row<TData>): ReactNode {
         // Check if it is in students/teachers/projects column
         if (

--- a/src/components/DataTableSchools.tsx
+++ b/src/components/DataTableSchools.tsx
@@ -11,7 +11,7 @@
 
 "use client";
 import React, { ReactNode } from "react";
-import { ArrowUp, ArrowDown, Minus } from "lucide-react";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
 
 import {
     ColumnDef,
@@ -98,22 +98,22 @@ export function SchoolsDataTable<TData, TValue>({
         const formattedPercent = percentChange.toFixed(0);
         if (percentChange < 0.5) {
             return (
-                <div className="flex items-center justify-center space-x-1 text-[#808080]">
-                    <Minus />
+                <div className="flex items-center justify-center gap-1 text-[#808080]">
+                    <Minus size={14} />
                     {formattedPercent}%
                 </div>
             );
         } else if (diff > 0) {
             return (
-                <div className="flex items-center justify-center space-x-1 text-[#46A758]">
-                    <ArrowUp />
+                <div className="flex items-center justify-center gap-1 text-[#46A758]">
+                    <TrendingUp size={14} />
                     {formattedPercent}%
                 </div>
             );
         } else if (diff < 0) {
             return (
-                <div className="flex items-center justify-center space-x-1 text-[#E5484D]">
-                    <ArrowDown />
+                <div className="flex items-center justify-center gap-1 text-[#E5484D]">
+                    <TrendingDown size={14} />
                     {formattedPercent}%
                 </div>
             );

--- a/src/components/DataTableSchools.tsx
+++ b/src/components/DataTableSchools.tsx
@@ -80,31 +80,35 @@ export function SchoolsDataTable<TData, TValue>({
         }
         const rowIndex: number = row.index;
         const prevRow = prevData[rowIndex] as Record<string, number>;
+
+        if (!prevRow) return <></>;
         const colIndex: number = cell.column.getIndex();
-        const prevYearValue: number = prevRow[cell.column.id];
+        const prevYearValue: number = prevRow[cell.column.id] ?? 0;
         const diff = cell.getValue() - prevYearValue;
 
-        const percentChange = Math.abs(diff / prevYearValue) * 100;
+        const percentChange =
+            prevYearValue !== 0 ? Math.abs(diff / prevYearValue) * 100 : 0;
 
-        if (diff > 0) {
+        const formattedPercent = percentChange.toFixed(0);
+        if (percentChange < 0.5) {
             return (
-                <div>
+                <div className="flex items-center justify-center space-x-1 text-[#808080]">
+                    <Minus />
+                    {formattedPercent}%
+                </div>
+            );
+        } else if (diff > 0) {
+            return (
+                <div className="flex items-center justify-center space-x-1 text-[#46A758]">
                     <ArrowUp />
-                    {percentChange}
+                    {formattedPercent}%
                 </div>
             );
         } else if (diff < 0) {
             return (
-                <div>
+                <div className="flex items-center justify-center space-x-1 text-[#E5484D]">
                     <ArrowDown />
-                    {percentChange}
-                </div>
-            );
-        } else {
-            return (
-                <div>
-                    <ArrowDown />
-                    {percentChange}
+                    {formattedPercent}%
                 </div>
             );
         }
@@ -173,7 +177,7 @@ export function SchoolsDataTable<TData, TValue>({
                                                 )}
                                             </Link>
                                         ) : (
-                                            <div>
+                                            <div className="flex flex-row items-center justify-center space-x-1 gap-2 h-12">
                                                 {flexRender(
                                                     cell.column.columnDef.cell,
                                                     cell.getContext(),

--- a/src/components/DataTableSchools.tsx
+++ b/src/components/DataTableSchools.tsx
@@ -10,7 +10,9 @@
  **************************************************************/
 
 "use client";
-import React from "react";
+import React, { ReactNode } from "react";
+import { ArrowUp, ArrowDown, Minus } from "lucide-react";
+
 import {
     ColumnDef,
     flexRender,
@@ -19,6 +21,8 @@ import {
     useReactTable,
     SortingState,
     getSortedRowModel,
+    Cell,
+    Row,
 } from "@tanstack/react-table";
 
 import {
@@ -31,10 +35,12 @@ import {
 } from "@/components/ui/table";
 
 import Link from "next/link";
+import { Arrow } from "@radix-ui/react-popover";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
     data: TData[];
+    prevData: TData[];
     globalFilter: string;
     setGlobalFilter: (value: string) => void;
 }
@@ -42,6 +48,7 @@ interface DataTableProps<TData, TValue> {
 export function SchoolsDataTable<TData, TValue>({
     columns,
     data,
+    prevData,
     globalFilter,
     setGlobalFilter,
 }: DataTableProps<TData, TValue>) {
@@ -61,6 +68,50 @@ export function SchoolsDataTable<TData, TValue>({
             globalFilter,
         },
     });
+
+    function yoyChange(cell: Cell<TData, number>, row: Row<TData>): ReactNode {
+        // Check if it is in students/teachers/projects column
+        if (
+            cell.column.getIndex() !== 5 &&
+            cell.column.getIndex() !== 6 &&
+            cell.column.getIndex() !== 7
+        ) {
+            return <></>;
+        }
+        const rowIndex: number = row.index;
+        const prevRow = prevData[rowIndex] as Record<string, number>;
+        const colIndex: number = cell.column.getIndex();
+        const prevYearValue: number = prevRow[cell.column.id];
+        const diff = cell.getValue() - prevYearValue;
+
+        const percentChange = Math.abs(diff / prevYearValue) * 100;
+
+        if (diff > 0) {
+            return (
+                <div>
+                    <ArrowUp />
+                    {percentChange}
+                </div>
+            );
+        } else if (diff < 0) {
+            return (
+                <div>
+                    <ArrowDown />
+                    {percentChange}
+                </div>
+            );
+        } else {
+            return (
+                <div>
+                    <ArrowDown />
+                    {percentChange}
+                </div>
+            );
+        }
+
+        // If so, calc year over year change
+        // Render icon/number based on that
+    }
 
     return (
         //Example code should be changed
@@ -127,6 +178,7 @@ export function SchoolsDataTable<TData, TValue>({
                                                     cell.column.columnDef.cell,
                                                     cell.getContext(),
                                                 )}
+                                                {yoyChange(cell, row)}
                                             </div>
                                         )}
                                     </TableCell>

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -16,7 +16,7 @@ type LineGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRefCopy?: React.RefObject<SVGSVGElement | null>;
+    svgRef?: React.RefObject<SVGSVGElement | null>;
     config?: ChartConfig;
     tooltipFormatter?: TooltipFormatter;
 };
@@ -26,7 +26,7 @@ export default function MultiLineGraph({
     yAxisLabel,
     xAxisLabel,
     legendTitle,
-    svgRefCopy,
+    svgRef,
     config,
     tooltipFormatter,
 }: LineGraphProps) {
@@ -51,7 +51,7 @@ export default function MultiLineGraph({
         .map((d) => Number(d.x))
         .filter((n) => Number.isFinite(n));
     const xExtent = extent(xNums) as [number, number];
-    if (xExtent[0] == null) return null;
+    if (xExtent[0] === null) return null;
 
     const xScale = scaleLinear().domain(xExtent).range([0, 100]);
     const yScale = scaleLinear()
@@ -145,7 +145,7 @@ export default function MultiLineGraph({
             >
                 <svg
                     ref={(el) => {
-                        if (svgRefCopy !== undefined) svgRefCopy.current = el;
+                        if (svgRef !== undefined) svgRef.current = el;
                     }}
                     viewBox="0 0 100 100"
                     className="w-full h-full overflow-visible"

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -16,7 +16,7 @@ type LineGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRef?: React.RefObject<SVGSVGElement | null>;
+    chartRef?: React.RefObject<HTMLDivElement | null>;
     config?: ChartConfig;
     tooltipFormatter?: TooltipFormatter;
 };
@@ -26,7 +26,7 @@ export default function MultiLineGraph({
     yAxisLabel,
     xAxisLabel,
     legendTitle,
-    svgRef,
+    chartRef,
     config,
     tooltipFormatter,
 }: LineGraphProps) {
@@ -80,7 +80,11 @@ export default function MultiLineGraph({
     const chartHeight = chartBottom - chartTop;
 
     return (
-        <div className="relative w-full select-none" style={{ height }}>
+        <div
+            ref={chartRef}
+            className="relative w-full select-none"
+            style={{ height }}
+        >
             {/* Tooltip */}
             {tooltip && (
                 <div
@@ -107,15 +111,12 @@ export default function MultiLineGraph({
             >
                 {/* Rotated axis title — occupies leftmost 16px */}
                 <div
-                    className="absolute inset-y-0 flex items-center justify-center"
+                    className="absolute inset-y-0 flex items-center justify-center overflow-visible"
                     style={{ left: 0, width: 16 }}
                 >
                     <span
                         className="text-xs text-muted-foreground whitespace-nowrap pointer-events-none"
-                        style={{
-                            writingMode: "vertical-rl",
-                            transform: "rotate(180deg)",
-                        }}
+                        style={{ transform: "rotate(-90deg)" }}
                     >
                         {yAxisLabel}
                     </span>
@@ -144,9 +145,6 @@ export default function MultiLineGraph({
                 }}
             >
                 <svg
-                    ref={(el) => {
-                        if (svgRef !== undefined) svgRef.current = el;
-                    }}
                     viewBox="0 0 100 100"
                     className="w-full h-full overflow-visible"
                     preserveAspectRatio="none"

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { scaleLinear, max, extent, line as d3Line } from "d3";
+import { scaleLinear, max, extent, line as d3Line, area as d3Area } from "d3";
 import {
     ChartDataset,
     ChartConfig,
@@ -40,7 +40,7 @@ export default function MultiLineGraph({
     const mTop = config?.margin?.top ?? 6;
     const mRight = config?.margin?.right ?? 8;
     const mBottom = config?.margin?.bottom ?? 80;
-    const mLeft = config?.margin?.left ?? 50;
+    const mLeft = config?.margin?.left ?? 54;
     const strokeWidth = config?.strokeWidth ?? 2;
     const dotRadius = config?.dotRadius ?? 6;
 
@@ -62,6 +62,11 @@ export default function MultiLineGraph({
     const lineGen = d3Line<{ x: string | number; y: number }>()
         .x((d) => xScale(Number(d.x)))
         .y((d) => yScale(d.y));
+
+    const areaGen = d3Area<{ x: string | number; y: number }>()
+        .x((d) => xScale(Number(d.x)))
+        .y0(100)
+        .y1((d) => yScale(d.y));
 
     const formatTooltip: TooltipFormatter =
         tooltipFormatter ?? ((d) => String(d.y));
@@ -121,7 +126,7 @@ export default function MultiLineGraph({
                     <div
                         key={i}
                         style={{ top: `${yScale(value)}%`, left: 24, right: 0 }}
-                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-2"
+                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-4"
                     >
                         {value.toLocaleString()}
                     </div>
@@ -163,6 +168,49 @@ export default function MultiLineGraph({
                             />
                         </g>
                     ))}
+
+                    {/* Gradient defs */}
+                    <defs>
+                        {datasets.map((ds, i) => (
+                            <linearGradient
+                                key={ds.label}
+                                id={`area-gradient-${i}`}
+                                x1="0"
+                                y1="0"
+                                x2="0"
+                                y2="1"
+                            >
+                                <stop
+                                    offset="0%"
+                                    stopColor={
+                                        CHART_COLORS[i % CHART_COLORS.length]
+                                    }
+                                    stopOpacity={0.2}
+                                />
+                                <stop
+                                    offset="100%"
+                                    stopColor={
+                                        CHART_COLORS[i % CHART_COLORS.length]
+                                    }
+                                    stopOpacity={0}
+                                />
+                            </linearGradient>
+                        ))}
+                    </defs>
+
+                    {/* Area fills */}
+                    {datasets.map((ds, i) => {
+                        const a = areaGen(ds.data);
+                        if (!a) return null;
+                        return (
+                            <path
+                                key={ds.label}
+                                d={a}
+                                fill={`url(#area-gradient-${i})`}
+                                stroke="none"
+                            />
+                        );
+                    })}
 
                     {/* Lines */}
                     {datasets.map((ds, i) => {

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -14,7 +14,7 @@ type MultiLineGraphProps = {
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
-    svgRefCopy: React.RefObject<SVGSVGElement | null>;
+    svgRefCopy?: React.RefObject<SVGSVGElement | null>;
 };
 
 export default function MultiLineGraph({
@@ -416,7 +416,9 @@ export default function MultiLineGraph({
             });
         });
 
-        svgRefCopy.current = svgRef.current;
+        if (svgRefCopy != null) {
+            svgRefCopy.current = svgRef.current;
+        }
     }, [datasets, xAxisLabel, yAxisLabel, colorScale]);
 
     return (

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -1,27 +1,15 @@
 "use client";
 
-import * as d3 from "d3";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { useState } from "react";
+import { scaleLinear, max, extent, line as d3Line } from "d3";
 import {
     ChartDataset,
     ChartConfig,
-    ChartMargin,
     TooltipFormatter,
+    CHART_COLORS,
 } from "./chartTypes";
 
-// Re-export for callers that use the old name
 export type { ChartDataset as GraphDataset };
-
-const DEFAULT_MARGIN: ChartMargin = {
-    top: 20,
-    right: 20,
-    bottom: 100,
-    left: 60,
-};
-const DEFAULT_HEIGHT = 400;
-const DEFAULT_DOT_RADIUS = 4;
-const DEFAULT_STROKE_WIDTH = 2;
 
 type LineGraphProps = {
     datasets: ChartDataset[];
@@ -42,321 +30,272 @@ export default function MultiLineGraph({
     config,
     tooltipFormatter,
 }: LineGraphProps) {
-    const svgRef = useRef<SVGSVGElement | null>(null);
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const tooltipRef = useRef<d3.Selection<
-        HTMLDivElement,
-        unknown,
-        null,
-        undefined
-    > | null>(null);
-    const [containerWidth, setContainerWidth] = useState(0);
+    const [tooltip, setTooltip] = useState<{
+        x: number;
+        y: number;
+        content: string;
+    } | null>(null);
 
-    const margin: ChartMargin = { ...DEFAULT_MARGIN, ...config?.margin };
-    const height = config?.height ?? DEFAULT_HEIGHT;
-    const dotRadius = config?.dotRadius ?? DEFAULT_DOT_RADIUS;
-    const strokeWidth = config?.strokeWidth ?? DEFAULT_STROKE_WIDTH;
+    const height = config?.height ?? 400;
+    const mTop = config?.margin?.top ?? 6;
+    const mRight = config?.margin?.right ?? 8;
+    const mBottom = config?.margin?.bottom ?? 80;
+    const mLeft = config?.margin?.left ?? 50;
+    const strokeWidth = config?.strokeWidth ?? 2;
+    const dotRadius = config?.dotRadius ?? 6;
 
-    const colorScale = useMemo(
-        () => d3.scaleOrdinal(d3.schemeCategory10.map((c) => c.toString())),
-        [],
-    );
+    const allPoints = datasets.flatMap((d) => d.data);
+    if (allPoints.length === 0) return null;
 
-    // Track container width responsively
-    useEffect(() => {
-        if (!wrapperRef.current) return;
-        const observer = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                setContainerWidth(entry.contentRect.width);
-            }
-        });
-        observer.observe(wrapperRef.current);
-        return () => observer.disconnect();
-    }, []);
+    const xNums = allPoints
+        .map((d) => Number(d.x))
+        .filter((n) => Number.isFinite(n));
+    const xExtent = extent(xNums) as [number, number];
+    if (xExtent[0] == null) return null;
 
-    // Cleanup tooltip on unmount
-    useEffect(() => {
-        return () => {
-            tooltipRef.current?.remove();
-            tooltipRef.current = null;
-        };
-    }, []);
+    const xScale = scaleLinear().domain(xExtent).range([0, 100]);
+    const yScale = scaleLinear()
+        .domain([0, max(allPoints.map((d) => d.y)) ?? 10])
+        .range([100, 0])
+        .nice();
 
-    useEffect(() => {
-        if (
-            !svgRef.current ||
-            !wrapperRef.current ||
-            datasets.length === 0 ||
-            containerWidth === 0
-        ) {
-            return;
-        }
+    const lineGen = d3Line<{ x: string | number; y: number }>()
+        .x((d) => xScale(Number(d.x)))
+        .y((d) => yScale(d.y));
 
-        const width = containerWidth;
-        const svg = d3.select(svgRef.current);
-        svg.selectAll("*").remove();
+    const formatTooltip: TooltipFormatter =
+        tooltipFormatter ?? ((d) => String(d.y));
+    const yTicks = yScale.ticks(8).filter((t) => Number.isInteger(t));
+    const xTicks = xScale.ticks().filter((t) => Number.isInteger(t));
+    const hasLegend = datasets.length > 1 || !!legendTitle;
 
-        if (!tooltipRef.current) {
-            tooltipRef.current = d3
-                .select(wrapperRef.current)
-                .append("div")
-                .attr("class", "d3-tooltip")
-                .style("position", "absolute")
-                .style("opacity", 0)
-                .style("background", "black")
-                .style("color", "white")
-                .style("padding", "0.5rem")
-                .style("border-radius", "0.375rem")
-                .style("font-size", "0.875rem")
-                .style("pointer-events", "none")
-                .style("transform", "translate(-50%, -125%)")
-                .style("z-index", "1000");
-        }
-
-        const tooltip = tooltipRef.current;
-        const formatTooltip: TooltipFormatter =
-            tooltipFormatter ?? ((d) => String(d.y));
-
-        const allPoints = datasets.flatMap((d) => d.data);
-        if (allPoints.length === 0) return;
-
-        const xValues = allPoints
-            .map((d) => {
-                const num = Number(d.x);
-                return Number.isFinite(num) ? num : null;
-            })
-            .filter((v): v is number => v !== null);
-
-        if (xValues.length === 0) {
-            toast.warning("LineGraph: No valid numeric x values found");
-            return;
-        }
-
-        const xExtent = d3.extent(xValues) as [number, number];
-        if (xExtent[0] == null || xExtent[1] == null) {
-            toast.warning("LineGraph: Invalid x extent");
-            return;
-        }
-
-        const x = d3
-            .scaleLinear()
-            .domain(xExtent)
-            .range([margin.left, width - margin.right]);
-
-        const y = d3
-            .scaleLinear()
-            .domain([0, d3.max(allPoints, (d) => d.y) || 10])
-            .range([height - margin.bottom, margin.top]);
-
-        const positionTooltip = (
-            event: MouseEvent | FocusEvent,
-            d: { x: string | number; y: number },
-            label: string,
-        ) => {
-            const wrapperRect = wrapperRef.current?.getBoundingClientRect();
-            if (!wrapperRect) return;
-
-            let clientX: number;
-            let clientY: number;
-
-            if (event.type === "focus") {
-                const circle = event.target as SVGCircleElement;
-                const circleRect = circle.getBoundingClientRect();
-                clientX = circleRect.left + circleRect.width / 2;
-                clientY = circleRect.top + circleRect.height / 2;
-            } else {
-                const mouseEvent = event as MouseEvent;
-                clientX = mouseEvent.clientX;
-                clientY = mouseEvent.clientY;
-            }
-
-            tooltip
-                .text(formatTooltip(d, label))
-                .transition()
-                .duration(100)
-                .style("opacity", 1)
-                .style("left", `${clientX - wrapperRect.left}px`)
-                .style("top", `${clientY - wrapperRect.top}px`);
-        };
-
-        // X-axis
-        const xTicks = x.ticks().filter((t) => Number.isInteger(t));
-        svg.append("g")
-            .attr("class", "x-axis")
-            .attr("transform", `translate(0,${height - margin.bottom})`)
-            .call(
-                d3.axisBottom(x).tickValues(xTicks).tickFormat(d3.format("d")),
-            )
-            .call((g) => g.selectAll(".tick line").remove())
-            .call((g) => g.select(".domain").remove());
-
-        svg.append("text")
-            .attr("text-anchor", "middle")
-            .attr("fill", "#555")
-            .attr("x", margin.left + (width - margin.left - margin.right) / 2)
-            .attr("y", height - margin.bottom + 40)
-            .text(xAxisLabel);
-
-        // Y-axis
-        const yTicks = y.ticks().filter((t) => Number.isInteger(t));
-        svg.append("g")
-            .attr("class", "y-axis")
-            .attr("transform", `translate(${margin.left},0)`)
-            .call(
-                d3
-                    .axisLeft(y)
-                    .tickValues(yTicks)
-                    .tickSize(-width + margin.left + margin.right),
-            )
-            .call((g) => g.selectAll(".tick line").attr("stroke", "#ccc"))
-            .call((g) => g.select(".domain").remove())
-            .call((g) => g.selectAll(".tick text").attr("fill", "#555"));
-
-        svg.append("text")
-            .attr("transform", "rotate(-90)")
-            .attr("text-anchor", "middle")
-            .attr("fill", "#555")
-            .attr("x", -margin.top - (height - margin.top - margin.bottom) / 2)
-            .attr("y", 15)
-            .text(yAxisLabel);
-
-        // Lines
-        const lineGen = d3
-            .line<{ x: string | number; y: number }>()
-            .x((d) => {
-                const num = Number(d.x);
-                return Number.isFinite(num) ? x(num) : 0;
-            })
-            .y((d) => y(d.y));
-
-        const linesGroup = svg.append("g").attr("class", "lines");
-        datasets.forEach((ds) => {
-            linesGroup
-                .append("path")
-                .attr("fill", "none")
-                .attr("stroke", colorScale(ds.label))
-                .attr("stroke-width", strokeWidth)
-                .attr("d", lineGen(ds.data));
-        });
-
-        // Dots
-        const dotsGroup = svg.append("g").attr("class", "dots");
-        datasets.forEach((ds) => {
-            dotsGroup
-                .selectAll(null)
-                .data(ds.data)
-                .enter()
-                .append("circle")
-                .attr("r", dotRadius)
-                .attr("fill", colorScale(ds.label))
-                .style("cursor", "pointer")
-                .attr("tabindex", 0)
-                .attr("cx", (d) => {
-                    const num = Number(d.x);
-                    return Number.isFinite(num) ? x(num) : 0;
-                })
-                .attr("cy", (d) => y(d.y))
-                .on("mouseover focus", function (event, d) {
-                    d3.select(this)
-                        .transition()
-                        .duration(100)
-                        .attr("r", dotRadius + 2);
-                    positionTooltip(event, d, ds.label);
-                })
-                .on("mouseout blur", function () {
-                    d3.select(this)
-                        .transition()
-                        .duration(100)
-                        .attr("r", dotRadius);
-                    tooltip.transition().duration(100).style("opacity", 0);
-                });
-        });
-
-        // Legend
-        const legendGroup = svg
-            .append("g")
-            .attr("class", "legend")
-            .attr(
-                "transform",
-                `translate(${margin.left}, ${height - margin.bottom + 80})`,
-            );
-
-        if (legendTitle) {
-            legendGroup
-                .append("text")
-                .attr("class", "legend-title")
-                .attr("x", 0)
-                .attr("y", -10)
-                .style("font-size", "14px")
-                .style("font-weight", "600")
-                .attr("fill", "currentColor")
-                .text(legendTitle);
-        }
-
-        const legendWidth = width - margin.left - margin.right;
-        const itemMargin = 10;
-        const rowHeight = 20;
-
-        const legendItems = legendGroup
-            .selectAll("g.legend-item")
-            .data(datasets)
-            .enter()
-            .append("g")
-            .attr("class", "legend-item");
-
-        legendItems
-            .append("rect")
-            .attr("width", 12)
-            .attr("height", 12)
-            .attr("fill", (d) => colorScale(d.label));
-
-        legendItems
-            .append("text")
-            .attr("x", 16)
-            .attr("y", 10)
-            .text((d) => d.label)
-            .style("font-size", "12px")
-            .attr("alignment-baseline", "middle");
-
-        requestAnimationFrame(() => {
-            let xOffset = 0;
-            let yOffset = 0;
-            legendItems.attr("transform", function () {
-                const bbox = (this as SVGGElement).getBBox();
-                const itemWidth = bbox.width + itemMargin;
-                if (xOffset + itemWidth > legendWidth && xOffset > 0) {
-                    xOffset = 0;
-                    yOffset += rowHeight;
-                }
-                const transform = `translate(${xOffset}, ${yOffset})`;
-                xOffset += itemWidth;
-                return transform;
-            });
-        });
-
-        if (svgRefCopy != null) {
-            svgRefCopy.current = svgRef.current;
-        }
-    }, [
-        datasets,
-        xAxisLabel,
-        yAxisLabel,
-        legendTitle,
-        containerWidth,
-        dotRadius,
-        strokeWidth,
-        colorScale,
-        tooltipFormatter,
-    ]);
+    // Derived pixel positions for explicit placement
+    const chartTop = mTop;
+    const chartBottom = height - mBottom;
+    const chartHeight = chartBottom - chartTop;
 
     return (
-        <div ref={wrapperRef} style={{ position: "relative", width: "100%" }}>
-            <svg
-                ref={svgRef}
-                width={containerWidth}
-                height={height}
-                style={{ overflow: "visible", display: "block" }}
-            />
+        <div className="relative w-full select-none" style={{ height }}>
+            {/* Tooltip */}
+            {tooltip && (
+                <div
+                    className="fixed z-50 bg-popover text-popover-foreground border border-border shadow-sm text-xs px-2 py-1 rounded-md pointer-events-none whitespace-nowrap"
+                    style={{
+                        left: tooltip.x,
+                        top: tooltip.y - 8,
+                        transform: "translate(-50%, -100%)",
+                    }}
+                >
+                    {tooltip.content}
+                </div>
+            )}
+
+            {/* Y-axis: rotated label strip + tick values */}
+            <div
+                className="absolute overflow-visible"
+                style={{
+                    top: chartTop,
+                    left: 0,
+                    width: mLeft,
+                    height: chartHeight,
+                }}
+            >
+                {/* Rotated axis title — occupies leftmost 16px */}
+                <div
+                    className="absolute inset-y-0 flex items-center justify-center"
+                    style={{ left: 0, width: 16 }}
+                >
+                    <span
+                        className="text-xs text-muted-foreground whitespace-nowrap pointer-events-none"
+                        style={{
+                            writingMode: "vertical-rl",
+                            transform: "rotate(180deg)",
+                        }}
+                    >
+                        {yAxisLabel}
+                    </span>
+                </div>
+
+                {/* Tick values — confined to right portion, away from label */}
+                {yTicks.map((value, i) => (
+                    <div
+                        key={i}
+                        style={{ top: `${yScale(value)}%`, left: 24, right: 0 }}
+                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-2"
+                    >
+                        {value.toLocaleString()}
+                    </div>
+                ))}
+            </div>
+
+            {/* Chart area (SVG only — no child divs) */}
+            <div
+                className="absolute"
+                style={{
+                    top: chartTop,
+                    left: mLeft,
+                    right: mRight,
+                    height: chartHeight,
+                }}
+            >
+                <svg
+                    ref={(el) => {
+                        if (svgRefCopy !== undefined) svgRefCopy.current = el;
+                    }}
+                    viewBox="0 0 100 100"
+                    className="w-full h-full overflow-visible"
+                    preserveAspectRatio="none"
+                >
+                    {/* Grid lines */}
+                    {yTicks.map((value, i) => (
+                        <g
+                            key={i}
+                            transform={`translate(0,${yScale(value)})`}
+                            className="text-border"
+                        >
+                            <line
+                                x1={0}
+                                x2={100}
+                                stroke="currentColor"
+                                strokeDasharray="6,5"
+                                strokeWidth={0.5}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                    ))}
+
+                    {/* Lines */}
+                    {datasets.map((ds, i) => {
+                        const d = lineGen(ds.data);
+                        if (!d) return null;
+                        return (
+                            <path
+                                key={ds.label}
+                                d={d}
+                                fill="none"
+                                stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                                strokeWidth={strokeWidth}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        );
+                    })}
+
+                    {/* Dots: invisible hit target + visible dot */}
+                    {datasets.map((ds, si) =>
+                        ds.data.map((point, pi) => {
+                            const cx = xScale(Number(point.x));
+                            const cy = yScale(point.y);
+                            const color =
+                                CHART_COLORS[si % CHART_COLORS.length];
+                            const content = formatTooltip(point, ds.label);
+                            return (
+                                <g key={`${si}-${pi}`}>
+                                    <path
+                                        d={`M ${cx} ${cy} l 0.0001 0`}
+                                        vectorEffect="non-scaling-stroke"
+                                        strokeWidth={16}
+                                        strokeLinecap="round"
+                                        fill="none"
+                                        stroke="transparent"
+                                        style={{ cursor: "pointer" }}
+                                        onMouseEnter={(e) =>
+                                            setTooltip({
+                                                x: e.clientX,
+                                                y: e.clientY,
+                                                content,
+                                            })
+                                        }
+                                        onMouseMove={(e) =>
+                                            setTooltip({
+                                                x: e.clientX,
+                                                y: e.clientY,
+                                                content,
+                                            })
+                                        }
+                                        onMouseLeave={() => setTooltip(null)}
+                                    />
+                                    <path
+                                        d={`M ${cx} ${cy} l 0.0001 0`}
+                                        vectorEffect="non-scaling-stroke"
+                                        strokeWidth={dotRadius}
+                                        strokeLinecap="round"
+                                        fill="none"
+                                        stroke={color}
+                                        style={{ pointerEvents: "none" }}
+                                    />
+                                </g>
+                            );
+                        }),
+                    )}
+                </svg>
+            </div>
+
+            {/* X-axis tick labels — explicitly below chart area */}
+            <div
+                className="absolute overflow-visible"
+                style={{ top: chartBottom + 6, left: mLeft, right: mRight }}
+            >
+                {xTicks.map((year, i) => {
+                    const isFirst = i === 0;
+                    const isLast = i === xTicks.length - 1;
+                    return (
+                        <div
+                            key={i}
+                            className="absolute overflow-visible text-muted-foreground"
+                            style={{
+                                left: `${xScale(year)}%`,
+                                transform: `translateX(${isFirst ? "0%" : isLast ? "-100%" : "-50%"})`,
+                            }}
+                        >
+                            <span className="text-xs tabular-nums">{year}</span>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* X-axis title */}
+            <div
+                className="absolute text-xs text-muted-foreground text-center"
+                style={{
+                    top: chartBottom + 28,
+                    left: mLeft,
+                    right: mRight,
+                }}
+            >
+                {xAxisLabel}
+            </div>
+
+            {/* Legend */}
+            {hasLegend && (
+                <div
+                    className="absolute flex flex-wrap items-center gap-x-4 gap-y-1"
+                    style={{
+                        top: chartBottom + 50,
+                        left: mLeft,
+                        right: mRight,
+                    }}
+                >
+                    {legendTitle && (
+                        <span className="text-xs font-semibold text-foreground w-full">
+                            {legendTitle}
+                        </span>
+                    )}
+                    {datasets.map((ds, i) => (
+                        <div key={i} className="flex items-center gap-1.5">
+                            <div
+                                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                                style={{
+                                    backgroundColor:
+                                        CHART_COLORS[i % CHART_COLORS.length],
+                                }}
+                            />
+                            <span className="text-xs text-muted-foreground">
+                                {ds.label}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import * as d3 from "d3";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+    ChartDataset,
+    ChartConfig,
+    ChartMargin,
+    TooltipFormatter,
+} from "./chartTypes";
 
-export type GraphDataset = {
-    label: string;
-    data: { x: string | number; y: number }[];
+// Re-export for callers that use the old name
+export type { ChartDataset as GraphDataset };
+
+const DEFAULT_MARGIN: ChartMargin = {
+    top: 20,
+    right: 20,
+    bottom: 100,
+    left: 60,
 };
+const DEFAULT_HEIGHT = 400;
+const DEFAULT_DOT_RADIUS = 4;
+const DEFAULT_STROKE_WIDTH = 2;
 
-type MultiLineGraphProps = {
-    datasets: GraphDataset[];
+type LineGraphProps = {
+    datasets: ChartDataset[];
     yAxisLabel: string;
     xAxisLabel: string;
     legendTitle?: string;
     svgRefCopy?: React.RefObject<SVGSVGElement | null>;
+    config?: ChartConfig;
+    tooltipFormatter?: TooltipFormatter;
 };
 
 export default function MultiLineGraph({
@@ -23,7 +39,9 @@ export default function MultiLineGraph({
     xAxisLabel,
     legendTitle,
     svgRefCopy,
-}: MultiLineGraphProps) {
+    config,
+    tooltipFormatter,
+}: LineGraphProps) {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const tooltipRef = useRef<d3.Selection<
@@ -32,30 +50,52 @@ export default function MultiLineGraph({
         null,
         undefined
     > | null>(null);
-    const isFirstRender = useRef(true);
-    const groupsRef = useRef<{
-        xAxis?: d3.Selection<SVGGElement, unknown, null, undefined>;
-        yAxis?: d3.Selection<SVGGElement, unknown, null, undefined>;
-        xAxisLabel?: d3.Selection<SVGTextElement, unknown, null, undefined>;
-        yAxisLabel?: d3.Selection<SVGTextElement, unknown, null, undefined>;
-        lines?: d3.Selection<SVGGElement, unknown, null, undefined>;
-        dots?: d3.Selection<SVGGElement, unknown, null, undefined>;
-        legend?: d3.Selection<SVGGElement, unknown, null, undefined>;
-    }>({});
+    const [containerWidth, setContainerWidth] = useState(0);
 
-    // Memoize color scale to prevent re-running useEffect unnecessarily
-    //const colorScale = useMemo(() => d3.scaleOrdinal(d3.schemeCategory10), []);
+    const margin: ChartMargin = { ...DEFAULT_MARGIN, ...config?.margin };
+    const height = config?.height ?? DEFAULT_HEIGHT;
+    const dotRadius = config?.dotRadius ?? DEFAULT_DOT_RADIUS;
+    const strokeWidth = config?.strokeWidth ?? DEFAULT_STROKE_WIDTH;
+
     const colorScale = useMemo(
         () => d3.scaleOrdinal(d3.schemeCategory10.map((c) => c.toString())),
         [],
     );
 
+    // Track container width responsively
     useEffect(() => {
-        const svg = d3.select(svgRef.current);
-        const svgNode = svg.node();
-        if (!svgNode || !wrapperRef.current) return;
+        if (!wrapperRef.current) return;
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setContainerWidth(entry.contentRect.width);
+            }
+        });
+        observer.observe(wrapperRef.current);
+        return () => observer.disconnect();
+    }, []);
 
-        // Create tooltip once (outside drawChart to prevent memory leak)
+    // Cleanup tooltip on unmount
+    useEffect(() => {
+        return () => {
+            tooltipRef.current?.remove();
+            tooltipRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (
+            !svgRef.current ||
+            !wrapperRef.current ||
+            datasets.length === 0 ||
+            containerWidth === 0
+        ) {
+            return;
+        }
+
+        const width = containerWidth;
+        const svg = d3.select(svgRef.current);
+        svg.selectAll("*").remove();
+
         if (!tooltipRef.current) {
             tooltipRef.current = d3
                 .select(wrapperRef.current)
@@ -74,18 +114,12 @@ export default function MultiLineGraph({
         }
 
         const tooltip = tooltipRef.current;
+        const formatTooltip: TooltipFormatter =
+            tooltipFormatter ?? ((d) => String(d.y));
 
-        if (datasets.length === 0) return;
-
-        const width = 900; // Match actual SVG width
-        const height = 400;
-        const margin = { top: 20, right: 20, bottom: 100, left: 60 };
-
-        // Flatten datasets for global min/max axis domains
         const allPoints = datasets.flatMap((d) => d.data);
         if (allPoints.length === 0) return;
 
-        // Convert x values to numbers for scaling, filtering out invalid values
         const xValues = allPoints
             .map((d) => {
                 const num = Number(d.x);
@@ -98,15 +132,15 @@ export default function MultiLineGraph({
             return;
         }
 
-        const xExtent = d3.extent(xValues);
-        if (!xExtent[0] || !xExtent[1]) {
+        const xExtent = d3.extent(xValues) as [number, number];
+        if (xExtent[0] == null || xExtent[1] == null) {
             toast.warning("LineGraph: Invalid x extent");
             return;
         }
 
         const x = d3
             .scaleLinear()
-            .domain(xExtent as [number, number])
+            .domain(xExtent)
             .range([margin.left, width - margin.right]);
 
         const y = d3
@@ -114,12 +148,11 @@ export default function MultiLineGraph({
             .domain([0, d3.max(allPoints, (d) => d.y) || 10])
             .range([height - margin.bottom, margin.top]);
 
-        // Helper to position tooltip correctly
         const positionTooltip = (
             event: MouseEvent | FocusEvent,
             d: { x: string | number; y: number },
+            label: string,
         ) => {
-            // Recalculate wrapper rect on each event to handle scrolling/resizing
             const wrapperRect = wrapperRef.current?.getBoundingClientRect();
             if (!wrapperRect) return;
 
@@ -127,113 +160,67 @@ export default function MultiLineGraph({
             let clientY: number;
 
             if (event.type === "focus") {
-                // For keyboard focus, use the circle's position
                 const circle = event.target as SVGCircleElement;
                 const circleRect = circle.getBoundingClientRect();
                 clientX = circleRect.left + circleRect.width / 2;
                 clientY = circleRect.top + circleRect.height / 2;
             } else {
-                // For mouse events, use the actual pointer position
                 const mouseEvent = event as MouseEvent;
                 clientX = mouseEvent.clientX;
                 clientY = mouseEvent.clientY;
             }
 
-            // Convert to wrapper-relative coordinates
-            const wrapperX = clientX - wrapperRect.left;
-            const wrapperY = clientY - wrapperRect.top;
-
             tooltip
-                .text(String(d.y))
+                .text(formatTooltip(d, label))
                 .transition()
                 .duration(100)
                 .style("opacity", 1)
-                .style("left", `${wrapperX}px`)
-                .style("top", `${wrapperY}px`);
+                .style("left", `${clientX - wrapperRect.left}px`)
+                .style("top", `${clientY - wrapperRect.top}px`);
         };
 
-        // Create stable groups if they don't exist
-        if (!groupsRef.current.xAxis) {
-            groupsRef.current.xAxis = svg
-                .append("g")
-                .attr("class", "x-axis")
-                .attr("transform", `translate(0,${height - margin.bottom})`);
-        }
-
-        if (!groupsRef.current.yAxis) {
-            groupsRef.current.yAxis = svg
-                .append("g")
-                .attr("class", "y-axis")
-                .attr("transform", `translate(${margin.left},0)`);
-        }
-
-        if (!groupsRef.current.xAxisLabel) {
-            groupsRef.current.xAxisLabel = svg
-                .append("text")
-                .attr("class", "x-axis-label")
-                .attr("text-anchor", "middle")
-                .attr("fill", "#555");
-        }
-
-        if (!groupsRef.current.yAxisLabel) {
-            groupsRef.current.yAxisLabel = svg
-                .append("text")
-                .attr("class", "y-axis-label")
-                .attr("transform", "rotate(-90)")
-                .attr("text-anchor", "middle")
-                .attr("fill", "#555");
-        }
-
-        if (!groupsRef.current.lines) {
-            groupsRef.current.lines = svg.append("g").attr("class", "lines");
-        }
-
-        if (!groupsRef.current.dots) {
-            groupsRef.current.dots = svg.append("g").attr("class", "dots");
-        }
-
-        if (!groupsRef.current.legend) {
-            groupsRef.current.legend = svg
-                .append("g")
-                .attr("class", "legend")
-                .attr(
-                    "transform",
-                    `translate(${margin.left}, ${height - margin.bottom + 80})`,
-                );
-        }
-
-        // Update X-axis
+        // X-axis
         const xTicks = x.ticks().filter((t) => Number.isInteger(t));
-        groupsRef.current.xAxis.call(
-            d3.axisBottom(x).tickValues(xTicks).tickFormat(d3.format("d")),
-        );
-        groupsRef.current.xAxis.selectAll(".tick line").remove();
-        groupsRef.current.xAxis.select(".domain").remove();
+        svg.append("g")
+            .attr("class", "x-axis")
+            .attr("transform", `translate(0,${height - margin.bottom})`)
+            .call(
+                d3.axisBottom(x).tickValues(xTicks).tickFormat(d3.format("d")),
+            )
+            .call((g) => g.selectAll(".tick line").remove())
+            .call((g) => g.select(".domain").remove());
 
-        // Update X-axis label
-        groupsRef.current.xAxisLabel
+        svg.append("text")
+            .attr("text-anchor", "middle")
+            .attr("fill", "#555")
             .attr("x", margin.left + (width - margin.left - margin.right) / 2)
             .attr("y", height - margin.bottom + 40)
             .text(xAxisLabel);
 
-        // Update Y-axis
+        // Y-axis
         const yTicks = y.ticks().filter((t) => Number.isInteger(t));
-        groupsRef.current.yAxis.call(
-            d3
-                .axisLeft(y)
-                .tickValues(yTicks)
-                .tickSize(-width + margin.left + margin.right),
-        );
-        groupsRef.current.yAxis.selectAll(".tick line").attr("stroke", "#ccc");
-        groupsRef.current.yAxis.select(".domain").remove();
-        groupsRef.current.yAxis.selectAll(".tick text").attr("fill", "#555");
+        svg.append("g")
+            .attr("class", "y-axis")
+            .attr("transform", `translate(${margin.left},0)`)
+            .call(
+                d3
+                    .axisLeft(y)
+                    .tickValues(yTicks)
+                    .tickSize(-width + margin.left + margin.right),
+            )
+            .call((g) => g.selectAll(".tick line").attr("stroke", "#ccc"))
+            .call((g) => g.select(".domain").remove())
+            .call((g) => g.selectAll(".tick text").attr("fill", "#555"));
 
-        // Update Y-axis label
-        groupsRef.current.yAxisLabel
+        svg.append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("text-anchor", "middle")
+            .attr("fill", "#555")
             .attr("x", -margin.top - (height - margin.top - margin.bottom) / 2)
             .attr("y", 15)
             .text(yAxisLabel);
 
+        // Lines
         const lineGen = d3
             .line<{ x: string | number; y: number }>()
             .x((d) => {
@@ -242,168 +229,99 @@ export default function MultiLineGraph({
             })
             .y((d) => y(d.y));
 
-        // Update lines using join pattern
-        if (!groupsRef.current.lines) return;
-        const lines = groupsRef.current.lines
-            .selectAll<SVGPathElement, GraphDataset>("path.line")
-            .data(datasets, (d: GraphDataset) => d.label);
+        const linesGroup = svg.append("g").attr("class", "lines");
+        datasets.forEach((ds) => {
+            linesGroup
+                .append("path")
+                .attr("fill", "none")
+                .attr("stroke", colorScale(ds.label))
+                .attr("stroke-width", strokeWidth)
+                .attr("d", lineGen(ds.data));
+        });
 
-        lines.exit().remove();
-
-        const linesEnter = lines
-            .enter()
-            .append("path")
-            .attr("class", "line")
-            .attr("fill", "none")
-            .attr("stroke-width", 2);
-
-        const linesUpdate = linesEnter.merge(lines);
-
-        linesUpdate
-            .attr("stroke", (d) => colorScale(d.label))
-            .attr("d", (d) => lineGen(d.data));
-
-        // Animate line drawing only on first render
-        // if (isFirstRender.current) {
-        //     linesUpdate.each(function () {
-        //         const path = d3.select(this);
-        //         const length = path.node()?.getTotalLength() || 0;
-        //         path.attr("stroke-dasharray", `${length} ${length}`)
-        //             .attr("stroke-dashoffset", length)
-        //             .transition()
-        //             .duration(1500)
-        //             .attr("stroke-dashoffset", 0);
-        //     });
-        // }
-
-        // Update dots using join pattern
-        if (!groupsRef.current.dots) return;
-        const dotsGroups = groupsRef.current.dots
-            .selectAll<SVGGElement, GraphDataset>("g.dots-group")
-            .data(datasets, (d: GraphDataset) => d.label);
-
-        dotsGroups.exit().remove();
-
-        const dotsGroupsEnter = dotsGroups
-            .enter()
-            .append("g")
-            .attr("class", "dots-group");
-
-        const dotsGroupsUpdate = dotsGroupsEnter.merge(dotsGroups);
-
-        // Update circles within each group
-        dotsGroupsUpdate.each(function (dataset) {
-            const group = d3.select(this);
-            const circles = group
-                .selectAll<
-                    SVGCircleElement,
-                    { x: string | number; y: number }
-                >("circle")
-                .data(dataset.data, (d, i) => `${d.x}-${d.y}-${i}`);
-
-            circles.exit().remove();
-
-            const circlesEnter = circles
+        // Dots
+        const dotsGroup = svg.append("g").attr("class", "dots");
+        datasets.forEach((ds) => {
+            dotsGroup
+                .selectAll(null)
+                .data(ds.data)
                 .enter()
                 .append("circle")
-                .attr("r", 4)
-                .attr("fill", colorScale(dataset.label))
+                .attr("r", dotRadius)
+                .attr("fill", colorScale(ds.label))
                 .style("cursor", "pointer")
                 .attr("tabindex", 0)
-                .on("mouseover focus", function (event, d) {
-                    d3.select(this).transition().duration(100).attr("r", 6);
-                    positionTooltip(event, d);
-                })
-                .on("mouseout blur", function () {
-                    d3.select(this).transition().duration(100).attr("r", 4);
-                    tooltip.transition().duration(100).style("opacity", 0);
-                });
-
-            const circlesUpdate = circlesEnter.merge(circles);
-
-            circlesUpdate
                 .attr("cx", (d) => {
                     const num = Number(d.x);
                     return Number.isFinite(num) ? x(num) : 0;
                 })
-                .attr("cy", (d) => y(d.y));
-
-            // Animate points appearing only on first render
-            // if (isFirstRender.current) {
-            //     circlesUpdate
-            //         .attr("opacity", 0)
-            //         .transition()
-            //         .delay(500)
-            //         .duration(1000)
-            //         .attr("opacity", 1);
-            // } else {
-            circlesUpdate.attr("opacity", 1);
-            // }
+                .attr("cy", (d) => y(d.y))
+                .on("mouseover focus", function (event, d) {
+                    d3.select(this)
+                        .transition()
+                        .duration(100)
+                        .attr("r", dotRadius + 2);
+                    positionTooltip(event, d, ds.label);
+                })
+                .on("mouseout blur", function () {
+                    d3.select(this)
+                        .transition()
+                        .duration(100)
+                        .attr("r", dotRadius);
+                    tooltip.transition().duration(100).style("opacity", 0);
+                });
         });
 
-        // Mark that first render is complete
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
+        // Legend
+        const legendGroup = svg
+            .append("g")
+            .attr("class", "legend")
+            .attr(
+                "transform",
+                `translate(${margin.left}, ${height - margin.bottom + 80})`,
+            );
+
+        if (legendTitle) {
+            legendGroup
+                .append("text")
+                .attr("class", "legend-title")
+                .attr("x", 0)
+                .attr("y", -10)
+                .style("font-size", "14px")
+                .style("font-weight", "600")
+                .attr("fill", "currentColor")
+                .text(legendTitle);
         }
 
-        // Update legend using join pattern
         const legendWidth = width - margin.left - margin.right;
         const itemMargin = 10;
         const rowHeight = 20;
 
-        // Add or update legend title
-        const legendTitleSelection = groupsRef.current.legend
-            .selectAll<SVGTextElement, string>("text.legend-title")
-            .data(legendTitle ? [legendTitle] : []);
-
-        legendTitleSelection.exit().remove();
-
-        legendTitleSelection
-            .enter()
-            .append("text")
-            .attr("class", "legend-title")
-            .attr("x", 0)
-            .attr("y", -10)
-            .style("font-size", "14px")
-            .style("font-weight", "600")
-            .attr("fill", "currentColor")
-            .merge(legendTitleSelection)
-            .text((d) => d);
-
-        const legendItems = groupsRef.current.legend
-            .selectAll<SVGGElement, GraphDataset>("g.legend-item")
-            .data(datasets, (d) => d.label);
-
-        legendItems.exit().remove();
-
-        const legendItemsEnter = legendItems
+        const legendItems = legendGroup
+            .selectAll("g.legend-item")
+            .data(datasets)
             .enter()
             .append("g")
             .attr("class", "legend-item");
 
-        legendItemsEnter.append("rect").attr("width", 12).attr("height", 12);
+        legendItems
+            .append("rect")
+            .attr("width", 12)
+            .attr("height", 12)
+            .attr("fill", (d) => colorScale(d.label));
 
-        legendItemsEnter
+        legendItems
             .append("text")
             .attr("x", 16)
             .attr("y", 10)
+            .text((d) => d.label)
             .style("font-size", "12px")
             .attr("alignment-baseline", "middle");
 
-        const legendItemsUpdate = legendItemsEnter.merge(legendItems);
-
-        legendItemsUpdate
-            .select("rect")
-            .attr("fill", (d) => colorScale(d.label));
-
-        legendItemsUpdate.select("text").text((d) => d.label);
-
-        // Position legend items, wrap to new line on overflow
-        // Use requestAnimationFrame to ensure layout is complete before measuring
         requestAnimationFrame(() => {
             let xOffset = 0;
             let yOffset = 0;
-            legendItemsUpdate.attr("transform", function () {
+            legendItems.attr("transform", function () {
                 const bbox = (this as SVGGElement).getBBox();
                 const itemWidth = bbox.width + itemMargin;
                 if (xOffset + itemWidth > legendWidth && xOffset > 0) {
@@ -419,16 +337,26 @@ export default function MultiLineGraph({
         if (svgRefCopy != null) {
             svgRefCopy.current = svgRef.current;
         }
-    }, [datasets, xAxisLabel, yAxisLabel, colorScale]);
+    }, [
+        datasets,
+        xAxisLabel,
+        yAxisLabel,
+        legendTitle,
+        containerWidth,
+        dotRadius,
+        strokeWidth,
+        colorScale,
+        tooltipFormatter,
+    ]);
 
     return (
-        <div ref={wrapperRef} style={{ position: "relative" }}>
+        <div ref={wrapperRef} style={{ position: "relative", width: "100%" }}>
             <svg
                 ref={svgRef}
-                width={900}
-                height={400}
-                style={{ overflow: "visible" }}
-            ></svg>
+                width={containerWidth}
+                height={height}
+                style={{ overflow: "visible", display: "block" }}
+            />
         </div>
     );
 }

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -228,18 +228,40 @@ export default function MultiLineGraph({
                         );
                     })}
 
-                    {/* Dots: invisible hit target + visible dot */}
-                    {datasets.map((ds, si) =>
-                        ds.data.map((point, pi) => {
-                            const cx = xScale(Number(point.x));
-                            const cy = yScale(point.y);
-                            const color =
-                                CHART_COLORS[si % CHART_COLORS.length];
-                            const content = formatTooltip(point, ds.label);
-                            return (
-                                <g key={`${si}-${pi}`}>
+                    {/* Dots + hit targets sorted by cy desc so highest data value renders on top */}
+                    {(() => {
+                        const dots = datasets
+                            .flatMap((ds, si) =>
+                                ds.data.map((point) => ({
+                                    cx: xScale(Number(point.x)),
+                                    cy: yScale(point.y),
+                                    color: CHART_COLORS[
+                                        si % CHART_COLORS.length
+                                    ],
+                                    content: formatTooltip(point, ds.label),
+                                    key: `${si}-${String(point.x)}`,
+                                })),
+                            )
+                            .sort((a, b) => b.cy - a.cy); // high cy (low value) first, low cy (high value) last = on top
+
+                        return (
+                            <>
+                                {dots.map((dot) => (
                                     <path
-                                        d={`M ${cx} ${cy} l 0.0001 0`}
+                                        key={`dot-${dot.key}`}
+                                        d={`M ${dot.cx} ${dot.cy} l 0.0001 0`}
+                                        vectorEffect="non-scaling-stroke"
+                                        strokeWidth={dotRadius}
+                                        strokeLinecap="round"
+                                        fill="none"
+                                        stroke={dot.color}
+                                        style={{ pointerEvents: "none" }}
+                                    />
+                                ))}
+                                {dots.map((dot) => (
+                                    <path
+                                        key={`hit-${dot.key}`}
+                                        d={`M ${dot.cx} ${dot.cy} l 0.0001 0`}
                                         vectorEffect="non-scaling-stroke"
                                         strokeWidth={16}
                                         strokeLinecap="round"
@@ -250,31 +272,22 @@ export default function MultiLineGraph({
                                             setTooltip({
                                                 x: e.clientX,
                                                 y: e.clientY,
-                                                content,
+                                                content: dot.content,
                                             })
                                         }
                                         onMouseMove={(e) =>
                                             setTooltip({
                                                 x: e.clientX,
                                                 y: e.clientY,
-                                                content,
+                                                content: dot.content,
                                             })
                                         }
                                         onMouseLeave={() => setTooltip(null)}
                                     />
-                                    <path
-                                        d={`M ${cx} ${cy} l 0.0001 0`}
-                                        vectorEffect="non-scaling-stroke"
-                                        strokeWidth={dotRadius}
-                                        strokeLinecap="round"
-                                        fill="none"
-                                        stroke={color}
-                                        style={{ pointerEvents: "none" }}
-                                    />
-                                </g>
-                            );
-                        }),
-                    )}
+                                ))}
+                            </>
+                        );
+                    })()}
                 </svg>
             </div>
 

--- a/src/components/YearDropdown.tsx
+++ b/src/components/YearDropdown.tsx
@@ -28,16 +28,17 @@ type YearDropdownProps = {
     selectedYear?: number | null;
     onYearChange?: (year: number | null) => void;
     showDataIndicator?: boolean;
+    school?: string | null;
 };
 
 export default function YearDropdown({
     selectedYear,
     onYearChange,
     showDataIndicator = false,
+    school,
 }: YearDropdownProps) {
     const [year, setYear] = useState<number | null>(null);
     const [yearsWithData, setYearsWithData] = useState<Set<number>>(new Set());
-
     // Years from current year down to 10 years ago
     const currentYear = new Date().getFullYear();
     const years = Array.from({ length: 10 }, (_, i) => currentYear - i);
@@ -48,18 +49,42 @@ export default function YearDropdown({
 
     // Fetch years with data
     useEffect(() => {
-        const fetchYearsWithData = async () => {
-            try {
-                const response = await fetch("/api/years");
-                if (response.ok) {
-                    const data = await response.json();
-                    setYearsWithData(new Set(data.yearsWithData));
-                }
-            } catch (error) {
-                toast.error("Failed to load year data");
+        // If a school is passed in, gets the years with data for that specific
+        // school
+        if (school != null) {
+            for (let i = currentYear; i > 2016; i--) {
+                const fetchYearsWithData = async () => {
+                    try {
+                        const response = await fetch(
+                            `/api/schools/${school}?year=${i}`,
+                        );
+                        if (response.ok) {
+                            const data = await response.json();
+                            // Ensures that school has data for that year
+                            if (data.studentCount !== 0) {
+                                setYearsWithData(yearsWithData.add(i));
+                            }
+                        }
+                    } catch (error) {
+                        toast.error("Failed to load year data");
+                    }
+                };
+                fetchYearsWithData();
             }
-        };
-        fetchYearsWithData();
+        } else {
+            const fetchYearsWithData = async () => {
+                try {
+                    const response = await fetch("/api/years");
+                    if (response.ok) {
+                        const data = await response.json();
+                        setYearsWithData(new Set(data.yearsWithData));
+                    }
+                } catch (error) {
+                    toast.error("Failed to load year data");
+                }
+            };
+            fetchYearsWithData();
+        }
     }, []);
 
     const handleValueChange = (value: string) => {

--- a/src/components/YearDropdown.tsx
+++ b/src/components/YearDropdown.tsx
@@ -51,7 +51,7 @@ export default function YearDropdown({
     useEffect(() => {
         // If a school is passed in, gets the years with data for that specific
         // school
-        if (school != null) {
+        if (school !== null) {
             for (let i = currentYear; i > 2016; i--) {
                 const fetchYearsWithData = async () => {
                     try {

--- a/src/components/chartTypes.ts
+++ b/src/components/chartTypes.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared types for BarGraph and LineGraph components.
+ */
+
+export type ChartDataset = {
+    label: string;
+    data: { x: string | number; y: number }[];
+};
+
+export type ChartMargin = {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+};
+
+export type ChartConfig = {
+    /** Fixed height in px. Defaults to 400. Width is always responsive. */
+    height?: number;
+    margin?: Partial<ChartMargin>;
+    /** BarGraph: rounded corner radius on bar tops. Default: 2 */
+    cornerRadius?: number;
+    /** BarGraph: padding between bar groups (0–1). Default: 0.1 */
+    barPadding?: number;
+    /** LineGraph: data point dot radius. Default: 4 */
+    dotRadius?: number;
+    /** LineGraph: line stroke width. Default: 2 */
+    strokeWidth?: number;
+};
+
+/**
+ * Receives the hovered data point and its series label.
+ * Return the string to display in the tooltip.
+ */
+export type TooltipFormatter = (
+    point: { x: string | number; y: number },
+    seriesLabel: string,
+) => string;

--- a/src/components/chartTypes.ts
+++ b/src/components/chartTypes.ts
@@ -1,6 +1,19 @@
 /**
- * Shared types for BarGraph and LineGraph components.
+ * Shared types and constants for BarGraph and LineGraph components.
  */
+
+export const CHART_COLORS = [
+    "#3b82f6", // blue-500
+    "#f59e0b", // amber-500
+    "#10b981", // emerald-500
+    "#ef4444", // red-500
+    "#8b5cf6", // violet-500
+    "#ec4899", // pink-500
+    "#06b6d4", // cyan-500
+    "#84cc16", // lime-500
+    "#f97316", // orange-500
+    "#6366f1", // indigo-500
+];
 
 export type ChartDataset = {
     label: string;

--- a/src/lib/export-to-pdf.ts
+++ b/src/lib/export-to-pdf.ts
@@ -38,24 +38,25 @@ export function downloadGraphs(cart: string[], filterNames: string[]) {
             const imgWidth = pdf.internal.pageSize.getWidth();
             const imgHeight = (img.height / img.width) * imgWidth;
 
+            // TODO: Change to DM Sans
             pdf.setFont("interstate-bold", "normal");
 
             pdf.text(`${month}/${day}/${year}`, 170, 15);
             pdf.addImage(
                 logoImg.src,
                 "PNG",
-                20,
+                15,
                 10,
                 logoImg.width * 0.03,
                 logoImg.height * 0.03,
             );
 
-            pdf.text(filterNames[idx], 25, 50);
+            pdf.text(filterNames[idx], 15, 50);
 
             pdf.addImage(
                 canvas,
                 "JPEG",
-                10,
+                15,
                 55,
                 imgWidth * 0.9,
                 imgHeight * 0.9,
@@ -68,103 +69,36 @@ export function downloadGraphs(cart: string[], filterNames: string[]) {
     });
 }
 
-export function getClonedSvg(
-    svgRef: React.RefObject<SVGSVGElement | null>,
-): SVGSVGElement | null {
-    const original = svgRef.current;
-    if (!original) return null;
-
-    //Creates and returns a clone of the svg element passed in
-    const clone = original.cloneNode(true) as SVGSVGElement;
-
-    return clone;
-}
-
 export async function addToCart(
-    svgRef: React.RefObject<SVGSVGElement | null>,
+    chartRef: React.RefObject<HTMLDivElement | null>,
     cart: string[],
     setCart: Dispatch<SetStateAction<string[]>>,
     filterNames: string[],
     setFilterNames: Dispatch<SetStateAction<string[]>>,
     filterName: string,
 ): Promise<void> {
-    const newSVG = getClonedSvg(svgRef);
-    if (!newSVG) return;
+    const el = chartRef.current;
+    if (!el) return;
 
-    // Get SVG dimensions from viewBox or attributes with fallbacks
-    const viewBox = newSVG.getAttribute("viewBox");
-    let svgWidth = 1000;
-    let svgHeight = 400;
-
-    if (viewBox) {
-        const viewBoxValues = viewBox.split(" ");
-        svgWidth = parseFloat(viewBoxValues[2]) || 1000;
-        svgHeight = parseFloat(viewBoxValues[3]) || 400;
-    } else {
-        const width = newSVG.getAttribute("width");
-        const height = newSVG.getAttribute("height");
-        if (width) svgWidth = parseFloat(width) || 1000;
-        if (height) svgHeight = parseFloat(height) || 400;
-    }
-
-    // Adds the svg element to the page temporarily (offscreen)
-    const wrapper = document.createElement("div");
-    wrapper.style.position = "fixed";
-    wrapper.style.left = "-9999px";
-    wrapper.style.top = "-9999px";
-    wrapper.style.width = `${svgWidth}px`;
-    wrapper.style.height = `${svgHeight}px`;
-    wrapper.appendChild(newSVG);
-    document.body.append(wrapper);
-
-    const canvas = await html2canvas(wrapper, {
+    const canvas = await html2canvas(el, {
         backgroundColor: "#fff",
         scale: 2,
     });
 
-    // Updates cart and filter names
     setCart([...cart, canvas.toDataURL()]);
     setFilterNames([...filterNames, filterName]);
-
-    document.body.removeChild(wrapper);
 }
 
 export async function downloadSingleGraph(
-    svgRef: React.RefObject<SVGSVGElement | null>,
+    chartRef: React.RefObject<HTMLDivElement | null>,
 ) {
-    const newSVG = getClonedSvg(svgRef);
-    if (!newSVG) return;
+    const el = chartRef.current;
+    if (!el) return;
 
-    // Get SVG dimensions from viewBox or attributes with fallbacks
-    const viewBox = newSVG.getAttribute("viewBox");
-    let svgWidth = 1000;
-    let svgHeight = 400;
-    let aspectRatio = svgHeight / svgWidth;
+    const { width, height } = el.getBoundingClientRect();
+    const aspectRatio = height / width;
 
-    if (viewBox) {
-        const viewBoxValues = viewBox.split(" ");
-        svgWidth = parseFloat(viewBoxValues[2]) || 1000;
-        svgHeight = parseFloat(viewBoxValues[3]) || 400;
-    } else {
-        const width = newSVG.getAttribute("width");
-        const height = newSVG.getAttribute("height");
-        if (width) svgWidth = parseFloat(width) || 1000;
-        if (height) svgHeight = parseFloat(height) || 400;
-    }
-
-    aspectRatio = svgHeight / svgWidth;
-
-    // Adds the svg element to the page temporarily (offscreen)
-    const wrapper = document.createElement("div");
-    wrapper.style.position = "fixed";
-    wrapper.style.left = "-9999px";
-    wrapper.style.top = "-9999px";
-    wrapper.style.width = `${svgWidth}px`;
-    wrapper.style.height = `${svgHeight}px`;
-    wrapper.appendChild(newSVG);
-    document.body.append(wrapper);
-
-    const canvas = await html2canvas(wrapper, {
+    const canvas = await html2canvas(el, {
         backgroundColor: "#fff",
         scale: 2,
     });
@@ -173,11 +107,8 @@ export async function downloadSingleGraph(
     const pdfWidth = pdf.internal.pageSize.getWidth();
     const pdfHeight = pdfWidth * aspectRatio;
 
-    // Add image with proper dimensions that match PDF width while preserving aspect ratio
     pdf.addImage(canvas, "JPEG", 0, 0, pdfWidth, pdfHeight);
     pdf.save("chart.pdf");
-
-    document.body.removeChild(wrapper);
 }
 
 export function clearCart(


### PR DESCRIPTION
## Sprint
[Sprint 6d]: Sprucing Up App w/ Graphs & Tables 📉 - Steven & Will #64

## Who worked on this sprint?
Will and Steven


## Who did what on this sprint?
Worked together

## Features Implemented
Add charts to dashboard
Add year selector to all school profile pages
Add charts to school profile
Add data table to school profile
Add growth/decline arrows to schools table

## New files created
none

## Existing files modified
src/components/dashboard.tsx
src/components/yeardropdown.tsx
src/app/schools/name/page.tsx
src/app/api/schools/[name]/route.ts
src/components/BarGraph.tsx
src/components/LineGraph.tsx
src/components/DataTableSchools.tsx
src/app/schools/page.tsx


## Acceptance Criteria
Dashboard displays meaningful charts that are fixed (non-editable) and link to a chart with the same configuration in Charts

Year selected added to school profile page, populate profile with relevant data for a specific school for the selected year

Dropdown options for year selector only show the years that a specific school participated

Charts for a specific school added to school profile pages and display data relevant to that specific school over time.

Charts on school profile page link to charts with the same configuration in Charts.

Table added to the bottom of school profile page displays raw data for a given school in that year

School profile table shows up/down and percentage change over previous year for counts columns

Schools table shows up/down and percentage change over previous year for counts columns

Tested exceptions such as schools with no participation change between years or schools with only one year of participation

UI matches Figma exactly

Code runs locally without errors and builds successfully

Merge via PR


The only acceptance criteria that was not completed was the UI matching figma, mostly because the figma's UI was inconsistent with the requirements of the ticket. We implemented the charts and data table on the overview/schools page as required, but the other parts on the figma such as the map were not implemented. Also, the figma was unclear about how to implement the view more button on charts, so we made an educated guess for how it should look.

School profile table shows up/down and percentage change over previous year for counts columns. This acceptance criteria was also not fully completed, because our school profilie table shows information about projects as is outlined in Step 4 of the ticket. However, it does not make logical sense to include up/down arrows when displaying qualitative information such as the names of projects.

## Testing: how did you test?
We used localhost, and made sure to test a variety of schools pages, such as ones with data and ones without.


## Features Not Implemented/Incomplete
Outlined in the acceptance criteria portion.


## Bugs Discovered
When charts are first rendered, it renders lines overlapping/2 sets of lines on the same chart. However, when refreshing, this issue goes away, so it is unclear how it came to be.


## Screenshots:
<!-- Show off your work -->
https://github.com/user-attachments/assets/edee4b7b-672f-4a55-aefb-acbdf6619554
https://github.com/user-attachments/assets/518af671-83ee-467a-8393-0112e1cf799d
https://github.com/user-attachments/assets/7315e053-0ed4-4930-b0e9-44e9aba97f44


## Tag Dan and Shayne
<!-- Also, add us as "Reviewers" on the right sidebar -->
@danglorioso @shaynesidman


<!-- Finally, tag your PR with the appropriate tags on the right sidebar -->
<!-- Including selecting your Issue in the "Development" section -->
<!-- And include you and your partner as "Asignees" -->
