### PR TITLE
Bug: Year selector on upload should be input 

### DIFF
--- a/src/components/SpreadsheetState.tsx
+++ b/src/components/SpreadsheetState.tsx
@@ -36,7 +36,7 @@ import {
 export default function SpreadsheetState() {
     const [file, setFile] = useState<File | undefined>();
     const [spreadsheetData, setSpreadsheetData] = useState<SpreadsheetData>([]);
-    const [year, setYear] = useState<number | null>(null);
+    const [year, setYear] = useState<number | null>(new Date().getFullYear());
     const [tab, setTab] = useState<ReactElement>(
         <SpreadsheetUpload
             file={file}

--- a/src/components/SpreadsheetState.tsx
+++ b/src/components/SpreadsheetState.tsx
@@ -122,6 +122,17 @@ export default function SpreadsheetState() {
         fetchKnownSchools();
     }, []);
 
+    // Set default year to most recent year without data once yearsWithData loads
+    useEffect(() => {
+        if (yearsWithData.size === 0) return;
+        const currentYear = new Date().getFullYear();
+        let defaultYear = currentYear;
+        while (defaultYear > 2000 && yearsWithData.has(defaultYear)) {
+            defaultYear--;
+        }
+        setYear(defaultYear);
+    }, [yearsWithData]);
+
     // Check if selected year has data whenever year changes
     useEffect(() => {
         setYearHasData(year !== null && yearsWithData.has(year));

--- a/src/components/SpreadsheetUpload.tsx
+++ b/src/components/SpreadsheetUpload.tsx
@@ -15,6 +15,7 @@
 import type React from "react";
 import FileUpload from "@/components/FileUpload";
 import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 import { ChevronLeft } from "lucide-react";
 import { ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -86,13 +87,13 @@ export default function SpreadsheetUpload({
                     </Button>
 
                     {/* Year Input */}
-                    <input
+                    <Input
                         type="number"
                         id="year"
                         name="Year"
                         value={yearStr}
                         onChange={handleYearInput}
-                        className="h-9 w-[100px] text-center border-y border-input focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     />
 
                     {/* Right Arrow Button */}

--- a/src/components/SpreadsheetUpload.tsx
+++ b/src/components/SpreadsheetUpload.tsx
@@ -14,11 +14,7 @@
 
 import type React from "react";
 import FileUpload from "@/components/FileUpload";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
-import { ChevronLeft } from "lucide-react";
-import { ChevronRight } from "lucide-react";
-import { useEffect, useState } from "react";
+import YearInput from "@/components/YearInput";
 
 type UploadProps = {
     file?: File;
@@ -33,38 +29,6 @@ export default function SpreadsheetUpload({
     year,
     setYear,
 }: UploadProps) {
-    const [yearStr, setYearStr] = useState("");
-    const currYear = Number(yearStr);
-
-    const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (year) {
-            const value = e.target.value;
-            const newYear = Number(value);
-            setYear(newYear);
-            setYearStr(value);
-        }
-    };
-
-    const incrementYear = () => {
-        if (year && currYear < 2100) {
-            const newYear = currYear + 1;
-            setYear(newYear);
-            setYearStr(String(newYear));
-        }
-    };
-
-    const decrementYear = () => {
-        if (year && currYear > 2000) {
-            const newYear = currYear - 1;
-            setYear(newYear);
-            setYearStr(String(newYear));
-        }
-    };
-
-    useEffect(() => {
-        setYearStr(String(year));
-    }, [year]);
-
     return (
         <div>
             <div className="flex flex-col gap-4">
@@ -76,35 +40,8 @@ export default function SpreadsheetUpload({
 
                 <h2 className="text-base mt-4">Year</h2>
 
-                <div className="flex items-center w-[180px] rounded-md overflow-hidden shadow-sm">
-                    {/* Left Arrow Button */}
-                    <Button
-                        variant="outline"
-                        onClick={decrementYear}
-                        className="h-9 w-10 flex items-center justify-center rounded-none border-r-0 shadow-none"
-                    >
-                        <ChevronLeft className="h-4 w-4" />
-                    </Button>
+                <YearInput year={year} setYear={setYear} />
 
-                    {/* Year Input */}
-                    <Input
-                        type="number"
-                        id="year"
-                        name="Year"
-                        value={yearStr}
-                        onChange={handleYearInput}
-                        className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                    />
-
-                    {/* Right Arrow Button */}
-                    <Button
-                        variant="outline"
-                        onClick={incrementYear}
-                        className="h-9 w-10 flex items-center justify-center rounded-none border-l-0 shadow-none"
-                    >
-                        <ChevronRight className="h-4 w-4" />
-                    </Button>
-                </div>
                 <div className="m-5" />
                 <FileUpload fileInfo={file} setFileInfo={setFile} />
             </div>

--- a/src/components/SpreadsheetUpload.tsx
+++ b/src/components/SpreadsheetUpload.tsx
@@ -14,7 +14,6 @@
 
 import type React from "react";
 import FileUpload from "@/components/FileUpload";
-import YearDropdown from "@/components/YearDropdown";
 import { Button } from "./ui/button";
 import { ChevronLeft } from "lucide-react";
 import { ChevronRight } from "lucide-react";

--- a/src/components/SpreadsheetUpload.tsx
+++ b/src/components/SpreadsheetUpload.tsx
@@ -15,6 +15,10 @@
 import type React from "react";
 import FileUpload from "@/components/FileUpload";
 import YearDropdown from "@/components/YearDropdown";
+import { Button } from "./ui/button";
+import { ChevronLeft } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
 
 type UploadProps = {
     file?: File;
@@ -29,6 +33,38 @@ export default function SpreadsheetUpload({
     year,
     setYear,
 }: UploadProps) {
+    const [yearStr, setYearStr] = useState("");
+    const currYear = Number(yearStr);
+
+    const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (year) {
+            const value = e.target.value;
+            const newYear = Number(value);
+            setYear(newYear);
+            setYearStr(value);
+        }
+    };
+
+    const incrementYear = () => {
+        if (year && currYear < 2100) {
+            const newYear = currYear + 1;
+            setYear(newYear);
+            setYearStr(String(newYear));
+        }
+    };
+
+    const decrementYear = () => {
+        if (year && currYear > 2000) {
+            const newYear = currYear - 1;
+            setYear(newYear);
+            setYearStr(String(newYear));
+        }
+    };
+
+    useEffect(() => {
+        setYearStr(String(year));
+    }, [year]);
+
     return (
         <div>
             <div className="flex flex-col gap-4">
@@ -37,13 +73,37 @@ export default function SpreadsheetUpload({
                     It&apos;s a new year! Time to upload the data required. You
                     can download the expected file format here.
                 </h2>
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-base mt-4">Year</h2>
-                    <YearDropdown
-                        showDataIndicator={true}
-                        selectedYear={year}
-                        onYearChange={setYear}
+
+                <h2 className="text-base mt-4">Year</h2>
+
+                <div className="flex items-center w-[180px] rounded-md overflow-hidden shadow-sm">
+                    {/* Left Arrow Button */}
+                    <Button
+                        variant="outline"
+                        onClick={decrementYear}
+                        className="h-9 w-10 flex items-center justify-center rounded-none border-r-0 shadow-none"
+                    >
+                        <ChevronLeft className="h-4 w-4" />
+                    </Button>
+
+                    {/* Year Input */}
+                    <input
+                        type="number"
+                        id="year"
+                        name="Year"
+                        value={yearStr}
+                        onChange={handleYearInput}
+                        className="h-9 w-[100px] text-center border-y border-input focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     />
+
+                    {/* Right Arrow Button */}
+                    <Button
+                        variant="outline"
+                        onClick={incrementYear}
+                        className="h-9 w-10 flex items-center justify-center rounded-none border-l-0 shadow-none"
+                    >
+                        <ChevronRight className="h-4 w-4" />
+                    </Button>
                 </div>
                 <div className="m-5" />
                 <FileUpload fileInfo={file} setFileInfo={setFile} />

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -13,11 +13,28 @@ type YearInputProps = {
 
 export default function YearInput({ year, setYear }: YearInputProps) {
     const [yearStr, setYearStr] = useState("");
+    const [yearsWithData, setYearsWithData] = useState<Set<number> | null>(
+        null,
+    );
     const currYear = Number(yearStr);
+
+    useEffect(() => {
+        async function fetchYearsWithData() {
+            try {
+                const res = await fetch("/api/years");
+                if (!res.ok) return;
+                const data = await res.json();
+                setYearsWithData(new Set(data.yearsWithData));
+            } catch {}
+        }
+        fetchYearsWithData();
+    }, []);
 
     useEffect(() => {
         setYearStr(String(year));
     }, [year]);
+
+    const hasData = !!currYear && !!yearsWithData?.has(currYear);
 
     const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (year) {
@@ -53,14 +70,21 @@ export default function YearInput({ year, setYear }: YearInputProps) {
                 <ChevronLeft className="h-4 w-4" />
             </Button>
 
-            <Input
-                type="number"
-                id="year"
-                name="Year"
-                value={yearStr}
-                onChange={handleYearInput}
-                className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-            />
+            <div className="relative">
+                {yearsWithData && yearStr && (
+                    <div
+                        className={`absolute left-2 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full shrink-0 ${hasData ? "bg-green-500" : "bg-red-500"}`}
+                    />
+                )}
+                <Input
+                    type="number"
+                    id="year"
+                    name="Year"
+                    value={yearStr}
+                    onChange={handleYearInput}
+                    className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                />
+            </div>
 
             <Button
                 variant="outline"

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type React from "react";
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type YearInputProps = {
+    year?: number | null;
+    setYear: (year: number | null) => void;
+};
+
+export default function YearInput({ year, setYear }: YearInputProps) {
+    const [yearStr, setYearStr] = useState("");
+    const currYear = Number(yearStr);
+
+    useEffect(() => {
+        setYearStr(String(year));
+    }, [year]);
+
+    const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (year) {
+            const value = e.target.value;
+            setYear(Number(value));
+            setYearStr(value);
+        }
+    };
+
+    const incrementYear = () => {
+        if (year && currYear < 2100) {
+            const newYear = currYear + 1;
+            setYear(newYear);
+            setYearStr(String(newYear));
+        }
+    };
+
+    const decrementYear = () => {
+        if (year && currYear > 2000) {
+            const newYear = currYear - 1;
+            setYear(newYear);
+            setYearStr(String(newYear));
+        }
+    };
+
+    return (
+        <div className="flex items-center w-[180px] rounded-md overflow-hidden shadow-sm">
+            <Button
+                variant="outline"
+                onClick={decrementYear}
+                className="h-9 w-10 flex items-center justify-center rounded-none border-r-0 shadow-none"
+            >
+                <ChevronLeft className="h-4 w-4" />
+            </Button>
+
+            <Input
+                type="number"
+                id="year"
+                name="Year"
+                value={yearStr}
+                onChange={handleYearInput}
+                className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            />
+
+            <Button
+                variant="outline"
+                onClick={incrementYear}
+                className="h-9 w-10 flex items-center justify-center rounded-none border-l-0 shadow-none"
+            >
+                <ChevronRight className="h-4 w-4" />
+            </Button>
+        </div>
+    );
+}

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -37,10 +37,17 @@ export default function YearInput({ year, setYear }: YearInputProps) {
     const hasData = !!currYear && !!yearsWithData?.has(currYear);
 
     const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (year) {
-            const value = e.target.value;
-            setYear(Number(value));
-            setYearStr(value);
+        const value = e.target.value;
+        if (value.length > 4) return;
+        setYearStr(value);
+        if (value.length === 4) setYear(Number(value));
+    };
+
+    const handleYearBlur = () => {
+        if (yearStr.length > 0 && yearStr.length < 4) {
+            const padded = yearStr.padStart(4, "0");
+            setYearStr(padded);
+            setYear(Number(padded));
         }
     };
 
@@ -82,6 +89,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
                     name="Year"
                     value={yearStr}
                     onChange={handleYearInput}
+                    onBlur={handleYearBlur}
                     className="h-9 w-[100px] text-center rounded-none border-y border-x-0 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
             </div>

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -18,6 +18,9 @@ export default function YearInput({ year, setYear }: YearInputProps) {
     );
     const currYear = Number(yearStr);
 
+    const MIN_YEAR = 1900;
+    const MAX_YEAR = 2100;
+
     useEffect(() => {
         async function fetchYearsWithData() {
             try {
@@ -52,7 +55,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
     };
 
     const incrementYear = () => {
-        if (year && currYear < 2100) {
+        if (year && currYear < MAX_YEAR) {
             const newYear = currYear + 1;
             setYear(newYear);
             setYearStr(String(newYear));
@@ -60,7 +63,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
     };
 
     const decrementYear = () => {
-        if (year && currYear > 2000) {
+        if (year && currYear > MIN_YEAR) {
             const newYear = currYear - 1;
             setYear(newYear);
             setYearStr(String(newYear));


### PR DESCRIPTION
Changed the year selector dropdown menu to a number input. I tried to maintain the style of the old year dropdown, including the arrows allowing a user to increment/decrement the year. The arrows do not allow the user to increment / decrement to values outside of the range between 2000 - 2100, but the user can enter any number field into the input. Also, I modified the default value for year in SpreadsheetState to be the current year since it helped avoid some problems with null props.

## Existing files modified
src/components/SpreadsheetState.tsx
src/components/SpreadsheetUpload.tsx

## Tag Dan and Shayne
<!-- Also, add us as "Reviewers" on the right sidebar -->
@danglorioso @shaynesidman

Closes #104 