### PR TITLE
Bug Fix: School locations must be within MA

### DIFF
--- a/src/app/api/coordinate-to-region/route.ts
+++ b/src/app/api/coordinate-to-region/route.ts
@@ -1,0 +1,35 @@
+/***************************************************************
+ *
+ *                /api/coordinate-to-region/route.ts
+ *
+ *         Author: Zander
+ *           Date: 4/4/2026
+ *
+ *        Summary: API to find the MA region of a given coordinate
+ *
+ **************************************************************/
+
+import { findRegionOf } from "@/lib/region-finder";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Returns region of a lat long coordinate.
+ *
+ * @param req NextRequest object
+ * @returns JSON response with success or error
+ */
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const lat = Number(searchParams.get("lat"));
+    const long = Number(searchParams.get("long"));
+
+    if (isNaN(lat) || isNaN(long)) {
+        return NextResponse.json(
+            { error: "Invalid lat/long parameters" },
+            { status: 400 },
+        );
+    }
+
+    const region = findRegionOf(lat, long);
+    return NextResponse.json({ region });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -283,6 +283,8 @@ function SchoolLocationEditor() {
                 `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
             );
             const data = await res.json();
+
+            // Location is only in MA if it has a region
             if (res.ok && data.region) {
                 validLocation = true;
             } else {
@@ -290,7 +292,8 @@ function SchoolLocationEditor() {
                     "A school's location must fall within Massachusetts.",
                 );
             }
-        } finally {
+        } catch {
+            toast.error("Error validating school location");
         }
 
         if (validLocation) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -275,8 +275,27 @@ function SchoolLocationEditor() {
         setNewPin(null);
     };
 
-    const handleMapClick = useCallback((lng: number, lat: number) => {
-        setNewPin({ latitude: lat, longitude: lng });
+    const handleMapClick = useCallback(async (long: number, lat: number) => {
+        let validLocation: boolean = false;
+
+        try {
+            const res = await fetch(
+                `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
+            );
+            const data = await res.json();
+            if (res.ok && data.region) {
+                validLocation = true;
+            } else {
+                toast.error(
+                    "A school's location must fall within Massachusetts.",
+                );
+            }
+        } finally {
+        }
+
+        if (validLocation) {
+            setNewPin({ latitude: lat, longitude: long });
+        }
     }, []);
 
     const handleSave = async () => {

--- a/src/components/SpreadsheetEdits.tsx
+++ b/src/components/SpreadsheetEdits.tsx
@@ -92,6 +92,8 @@ export default function SpreadsheetEdits({
                     `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
                 );
                 const data = await res.json();
+
+                // Location is only in MA if it has a region
                 if (res.ok && data.region) {
                     validLocation = true;
                 } else {
@@ -99,7 +101,8 @@ export default function SpreadsheetEdits({
                         "A school's location must fall within Massachusetts.",
                     );
                 }
-            } finally {
+            } catch {
+                toast.error("Error validating school location");
             }
 
             if (validLocation && currentSchool) {

--- a/src/components/SpreadsheetEdits.tsx
+++ b/src/components/SpreadsheetEdits.tsx
@@ -20,6 +20,7 @@ import type {
     UploadedSchool,
     SchoolWithCoordinates,
 } from "@/lib/school-matching";
+import { toast } from "sonner";
 
 interface SpreadsheetEditsProps {
     matchedSchools: SchoolWithCoordinates[];
@@ -83,9 +84,26 @@ export default function SpreadsheetEdits({
     const remainingCount = totalUnmatched - currentSchoolIndex;
 
     const handleMapClick = useCallback(
-        (lng: number, lat: number) => {
-            if (currentSchool) {
-                onSchoolLocationAssigned(currentSchool.schoolId, lat, lng);
+        async (long: number, lat: number) => {
+            let validLocation: boolean = false;
+
+            try {
+                const res = await fetch(
+                    `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
+                );
+                const data = await res.json();
+                if (res.ok && data.region) {
+                    validLocation = true;
+                } else {
+                    toast.error(
+                        "A school's location must fall within Massachusetts.",
+                    );
+                }
+            } finally {
+            }
+
+            if (validLocation && currentSchool) {
+                onSchoolLocationAssigned(currentSchool.schoolId, lat, long);
             }
         },
         [currentSchool, onSchoolLocationAssigned],

--- a/src/components/ui/mapPlacer.tsx
+++ b/src/components/ui/mapPlacer.tsx
@@ -158,6 +158,8 @@ export const MapPlacer = ({
                 `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
             );
             const data = await res.json();
+
+            // Location is only in MA if it has a region
             if (res.ok && data.region) {
                 validLocation = true;
             } else {
@@ -165,7 +167,8 @@ export const MapPlacer = ({
                     "A school's location must fall within Massachusetts.",
                 );
             }
-        } finally {
+        } catch {
+            toast.error("Error validating school location");
         }
 
         if (validLocation) {

--- a/src/components/ui/mapPlacer.tsx
+++ b/src/components/ui/mapPlacer.tsx
@@ -150,8 +150,27 @@ export const MapPlacer = ({
         setEditDialogOpen(true);
     };
 
-    const handleMapClick = useCallback((lng: number, lat: number) => {
-        setNewPin({ latitude: lat, longitude: lng });
+    const handleMapClick = useCallback(async (long: number, lat: number) => {
+        let validLocation: boolean = false;
+
+        try {
+            const res = await fetch(
+                `/api/coordinate-to-region/?lat=${lat}&long=${long}`,
+            );
+            const data = await res.json();
+            if (res.ok && data.region) {
+                validLocation = true;
+            } else {
+                toast.error(
+                    "A school's location must fall within Massachusetts.",
+                );
+            }
+        } finally {
+        }
+
+        if (validLocation) {
+            setNewPin({ latitude: lat, longitude: long });
+        }
     }, []);
 
     const handleSave = async () => {


### PR DESCRIPTION
#86 

## Features Implemented
Created a coordinate-to-region API point.
Limit picked locations on the 3 maps to be within MA (throws toast error otherwise).

## Existing files modified
src/components/SpreadsheetEdits.tsx
src/components/ui/mapPlacer.tsx

## Files added
src/app/api/coordinate-to-region/

## Screenshots:
<img width="1603" height="632" alt="image" src="https://github.com/user-attachments/assets/9ba2652d-7671-4d00-bd3b-ada4baedb9af" />

## Tag Dan and Shayne
@danglorioso @shaynesidman

Closes #86 
