### PR TITLE
Design Fix: Title "Gateway Schools" on Settings page

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -134,11 +134,11 @@ export default function Settings() {
                         </p>
                     </div>
                     <div className="space-y-6">
-                        <div className="space-y-3">
+                        <div>
                             <h3 className="font-bold">
                                 Schools in Gateway Cities
                             </h3>
-                            <h4>
+                            <h4 className="mb-2">
                                 Select schools that represent students from
                                 gateway cities.
                             </h4>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -135,7 +135,13 @@ export default function Settings() {
                     </div>
                     <div className="space-y-6">
                         <div className="space-y-3">
-                            <h3 className="font-bold">Gateway Cities</h3>
+                            <h3 className="font-bold">
+                                Schools in Gateway Cities
+                            </h3>
+                            <h4>
+                                Select schools that represent students from
+                                gateway cities.
+                            </h4>
                             <GatewaySchools
                                 ref={gatewaySchoolsRef}
                                 onUnsavedChange={() =>


### PR DESCRIPTION
#123

## Features Implemented
Fixed the title for "Gateway Cities" and added the requested subheading.

## Existing files modified
src/app/settings/page.tsx

## Screenshots:
<img width="1186" height="408" alt="image" src="https://github.com/user-attachments/assets/33b7adb8-d588-4b44-bc37-33c8d62b723c" />

## Tag Dan and Shayne
@danglorioso @shaynesidman

Closes #123
