### PR TITLE
changed which arrow is highlighted during each sort

### DIFF
--- a/src/components/icons/ChevronsUpDownSort.tsx
+++ b/src/components/icons/ChevronsUpDownSort.tsx
@@ -21,13 +21,13 @@ export function ChevronsUpDownSort({
     className,
 }: ChevronsUpDownSortProps) {
     const topStroke =
-        sortDirection === "asc" ? "var(--primary)" : "currentColor";
-    const bottomStroke =
         sortDirection === "desc" ? "var(--primary)" : "currentColor";
+    const bottomStroke =
+        sortDirection === "asc" ? "var(--primary)" : "currentColor";
     const topOpacity =
-        sortDirection === "asc" ? 1 : sortDirection === "desc" ? 0.35 : 0.6;
-    const bottomOpacity =
         sortDirection === "desc" ? 1 : sortDirection === "asc" ? 0.35 : 0.6;
+    const bottomOpacity =
+        sortDirection === "asc" ? 1 : sortDirection === "desc" ? 0.35 : 0.6;
 
     return (
         <svg


### PR DESCRIPTION
## Issue
<!-- Title and link the issue number here starting with an "#" -->
#129 

## Who worked on this sprint/bug?
<!-- List partner names -->
Chiara

## Features Implemented
<!-- List -->
Reverse the active/colored icon for the sorting states of the numeric variables in the school table.
Now, when the up arrow is highlighted, the values are sorted from largest to smallest. When the down arrow is highlighted, the values are highlighted from smallest to largest.

## New files created
<!-- List, including path -->
<!-- Remember to add headers to your code! -->
No new files created

## Existing files modified
<!-- List, including path -->
<!-- Scroll below to see modified files -->
components/icons/ChevronsUpDownSort.tsx

## Acceptance Criteria
<!-- Please include the acceptance criteria from the issue here
     and whether or not you completed each requirement -->
An up arrow should sort the values in descending order (highest first)
A down arrow should sort the values in ascending order (lowest first)

## Testing: how did you test?
<!-- Please describe how you tested your changes. -->
Tried selecting different sorting arrows in different orders and made sure the values were sorted as expected.

## Features Not Implemented/Incomplete
<!-- What features may not work yet or might have been broken by this PR -->
Lmk if this wasn't what the ticket was asking and I can fix it! 

## Bugs Discovered
<!-- List any existing bugs you encountered and
     whether or not you fixed them -->
None

## Screenshots:
<!-- Show off your work -->
<img width="409" height="291" alt="Screenshot 2026-04-08 at 12 38 17 PM" src="https://github.com/user-attachments/assets/5460dd7d-f0b7-4fca-85b5-60c4eba5de7e" />

## Tag Dan and Shayne
<!-- Also, add us as "Reviewers" on the right sidebar -->
@danglorioso @shaynesidman

<!-- Finally, tag your PR with the appropriate tags on the right sidebar -->
<!-- Including selecting your Issue in the "Development" section -->
<!-- And include you and your partner as "Asignees" -->
