### PR TITLE
Bug Fix: Numbers > 999 overlap on charts

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -576,6 +576,9 @@ export default function ChartPage() {
                 case "total-project-count":
                     return projects.length;
 
+                case "total-school-count":
+                    return new Set(projects.map((p) => p.schoolId)).size;
+
                 case "total-student-count":
                     return projects.reduce(
                         (sum, p) => sum + (p.numStudents || 0),

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -40,7 +40,6 @@ export default function BarGraph({
     const mTop = config?.margin?.top ?? 6;
     const mRight = config?.margin?.right ?? 25;
     const mBottom = config?.margin?.bottom ?? 80;
-    const mLeft = config?.margin?.left ?? 50;
     const barPadding = config?.barPadding ?? 0.25;
     const cornerRadius = config?.cornerRadius ?? 3;
 
@@ -60,6 +59,14 @@ export default function BarGraph({
         .padding(dataset.length > 1 ? 0.05 : 0);
 
     const yScale = scaleLinear().domain([0, maxY]).range([100, 0]).nice();
+
+    const maxTickLen = yScale
+        .ticks(8)
+        .filter((t) => Number.isInteger(t))
+        .reduce((a, b) => Math.max(a, b), 0)
+        .toLocaleString().length;
+
+    const mLeft = config?.margin?.left ?? Math.max(54, 24 + maxTickLen * 8);
 
     const formatTooltip: TooltipFormatter =
         tooltipFormatter ?? ((d) => String(d.y));

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -40,7 +40,6 @@ export default function MultiLineGraph({
     const mTop = config?.margin?.top ?? 6;
     const mRight = config?.margin?.right ?? 8;
     const mBottom = config?.margin?.bottom ?? 80;
-    const mLeft = config?.margin?.left ?? 54;
     const strokeWidth = config?.strokeWidth ?? 2;
     const dotRadius = config?.dotRadius ?? 6;
 
@@ -58,6 +57,14 @@ export default function MultiLineGraph({
         .domain([0, max(allPoints.map((d) => d.y)) ?? 10])
         .range([100, 0])
         .nice();
+
+    const maxTickLen = yScale
+        .ticks(8)
+        .filter((t) => Number.isInteger(t))
+        .reduce((a, b) => Math.max(a, b), 0)
+        .toLocaleString().length;
+
+    const mLeft = config?.margin?.left ?? Math.max(54, 24 + maxTickLen * 8);
 
     const lineGen = d3Line<{ x: string | number; y: number }>()
         .x((d) => xScale(Number(d.x)))

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -134,7 +134,7 @@ export default function MultiLineGraph({
                     <div
                         key={i}
                         style={{ top: `${yScale(value)}%`, left: 24, right: 0 }}
-                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-4"
+                        className="absolute text-xs tabular-nums -translate-y-1/2 text-muted-foreground text-right pr-2"
                     >
                         {value.toLocaleString()}
                     </div>


### PR DESCRIPTION
#154

## Features Implemented
Fixed overlapping numbers (>999) on axis. should scale to any digit size.

## Existing files modified
src/components/BarGraph.tsx
src/components/LineGraph.tsx

## Screenshots:
<img width="286" height="517" alt="image" src="https://github.com/user-attachments/assets/6cac2daf-b26e-4394-a321-000bc651635d" />

## Tag Dan and Shayne
@danglorioso @shaynesidman

Closes #154
