### PR TITLE
fix: only show schools with participation data for selected year

### DIFF
--- a/src/app/api/schools/route.ts
+++ b/src/app/api/schools/route.ts
@@ -153,8 +153,8 @@ export async function GET(req: NextRequest) {
             lastYearTeachers.map((t) => [t.schoolId, t.count]),
         );
 
-        // Combine data for each school
-        const schoolsToReturn = allSchools.map((school) => {
+        // Combine data for each school, excluding schools with no participation in the current year
+        const schoolsToReturn = allSchools.flatMap((school) => {
             const currProjects = currProjectsMap.get(school.id) ?? 0;
             const lastProjects = lastProjectsMap.get(school.id) ?? 0;
             const currStudents = currStudentsMap.get(school.id) ?? 0;
@@ -162,19 +162,29 @@ export async function GET(req: NextRequest) {
             const currTeachers = currTeachersMap.get(school.id) ?? 0;
             const lastTeachers = lastTeachersMap.get(school.id) ?? 0;
 
-            return {
-                name: school.name,
-                city: school.city,
-                region: school.region,
-                instructionModel: "Dummy 1", // TODO: Not in schema yet
-                implementationModel: "Dummy 1", // TODO: Not in schema yet
-                numStudents: currStudents,
-                studentChange: percentageChange(currStudents, lastStudents),
-                numTeachers: currTeachers,
-                teacherChange: percentageChange(currTeachers, lastTeachers),
-                numProjects: currProjects,
-                projectChange: percentageChange(currProjects, lastProjects),
-            };
+            if (
+                currProjects === 0 &&
+                currStudents === 0 &&
+                currTeachers === 0
+            ) {
+                return [];
+            }
+
+            return [
+                {
+                    name: school.name,
+                    city: school.city,
+                    region: school.region,
+                    instructionModel: "Dummy 1", // TODO: Not in schema yet
+                    implementationModel: "Dummy 1", // TODO: Not in schema yet
+                    numStudents: currStudents,
+                    studentChange: percentageChange(currStudents, lastStudents),
+                    numTeachers: currTeachers,
+                    teacherChange: percentageChange(currTeachers, lastTeachers),
+                    numProjects: currProjects,
+                    projectChange: percentageChange(currProjects, lastProjects),
+                },
+            ];
         });
 
         return NextResponse.json(schoolsToReturn);

--- a/src/app/api/schools/route.ts
+++ b/src/app/api/schools/route.ts
@@ -153,7 +153,7 @@ export async function GET(req: NextRequest) {
             lastYearTeachers.map((t) => [t.schoolId, t.count]),
         );
 
-        // Combine data for each school, excluding schools with no participation in the current year
+        // Combine data for each school excluding schools with no participation in the current year
         const schoolsToReturn = allSchools.flatMap((school) => {
             const currProjects = currProjectsMap.get(school.id) ?? 0;
             const lastProjects = lastProjectsMap.get(school.id) ?? 0;


### PR DESCRIPTION
Excludes schools with 0 students, teachers, and projects from the schools table for a given year. Fixes #128.

## Issue
<!-- Title and link the issue number here starting with an "#" -->
#128 Bug: School Page Only Show Participating Schools

## Who worked on this sprint/bug?
<!-- List partner names -->
Hansini Gundavarapu

## Features Implemented
<!-- List -->
Schools with no participation data (0 students, 0 teachers, 0 projects) for a selected year are now excluded from the schools table

## New files created
<!-- List, including path -->
<!-- Remember to add headers to your code! -->
No files created

## Existing files modified
<!-- List, including path -->
<!-- Scroll below to see modified files -->
src/app/api/schools/route.ts — added filter to exclude non-participating schools from the response

## Acceptance Criteria
<!-- Please include the acceptance criteria from the issue here
     and whether or not you completed each requirement -->
Schools that don't have participation data for a given year should not appear on the schools table (e.g. "Noble Greenough" no longer appears in 2025) - requirement complete

## Testing: how did you test?
<!-- Please describe how you tested your changes. -->
Ran the app locally and navigated to the Schools page.
Verified that schools with no students, teachers, or projects for a given year no longer appear in the table.
Verified that schools with participation data still appear correctly with year-over-year comparisons.

## Features Not Implemented/Incomplete
<!-- What features may not work yet or might have been broken by this PR -->
N/A

## Bugs Discovered
<!-- List any existing bugs you encountered and
     whether or not you fixed them -->
No new ones

## Tag Dan and Shayne
<!-- Also, add us as "Reviewers" on the right sidebar -->
@danglorioso @shaynesidman
