### PR TITLE
Fix/155 hide schools toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "@radix-ui/react-select": "^2.2.6",
                 "@radix-ui/react-separator": "^1.1.8",
                 "@radix-ui/react-slot": "^1.2.4",
+                "@radix-ui/react-switch": "^1.2.6",
                 "@radix-ui/react-tabs": "^1.1.13",
                 "@radix-ui/react-tooltip": "^1.2.8",
                 "@shadcn/ui": "^0.0.4",
@@ -3796,6 +3797,35 @@
             },
             "peerDependenciesMeta": {
                 "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+            "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
                     "optional": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@shadcn/ui": "^0.0.4",

--- a/src/app/api/schools/route.ts
+++ b/src/app/api/schools/route.ts
@@ -153,8 +153,8 @@ export async function GET(req: NextRequest) {
             lastYearTeachers.map((t) => [t.schoolId, t.count]),
         );
 
-        // Combine data for each school
-        const schoolsToReturn = allSchools.map((school) => {
+        // Combine data for each school, excluding schools with no participation in the current year
+        const schoolsToReturn = allSchools.flatMap((school) => {
             const currProjects = currProjectsMap.get(school.id) ?? 0;
             const lastProjects = lastProjectsMap.get(school.id) ?? 0;
             const currStudents = currStudentsMap.get(school.id) ?? 0;
@@ -162,19 +162,29 @@ export async function GET(req: NextRequest) {
             const currTeachers = currTeachersMap.get(school.id) ?? 0;
             const lastTeachers = lastTeachersMap.get(school.id) ?? 0;
 
-            return {
-                name: school.name,
-                city: school.city,
-                region: school.region,
-                instructionModel: "Dummy 1", // TODO: Not in schema yet
-                implementationModel: "Dummy 1", // TODO: Not in schema yet
-                numStudents: currStudents,
-                studentChange: percentageChange(currStudents, lastStudents),
-                numTeachers: currTeachers,
-                teacherChange: percentageChange(currTeachers, lastTeachers),
-                numProjects: currProjects,
-                projectChange: percentageChange(currProjects, lastProjects),
-            };
+            if (
+                currProjects === 0 &&
+                currStudents === 0 &&
+                currTeachers === 0
+            ) {
+                return [];
+            }
+
+            return [
+                {
+                    name: school.name,
+                    city: school.city,
+                    region: school.region,
+                    instructionModel: "Dummy 1", // TODO: Not in schema yet
+                    implementationModel: "Dummy 1", // TODO: Not in schema yet
+                    numStudents: currStudents,
+                    studentChange: percentageChange(currStudents, lastStudents),
+                    numTeachers: currTeachers,
+                    teacherChange: percentageChange(currTeachers, lastTeachers),
+                    numProjects: currProjects,
+                    projectChange: percentageChange(currProjects, lastProjects),
+                },
+            ];
         });
 
         return NextResponse.json(schoolsToReturn);

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -30,6 +30,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import YearDropdown from "@/components/YearDropdown";
 import CountDropdown from "@/components/CountDropdown";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { exportMapToPDF } from "@/lib/heatmap-export";
 import { useHeatmapLayers } from "@/hooks/useHeatmapLayers";
 import { Cart } from "@/components/Cart";
@@ -413,12 +414,19 @@ function HeatMapPage() {
                     </div>
                 </div>
 
-                <Button
-                    onClick={() => setShowSchools(!showSchools)}
-                    className="w-32 py-2"
-                >
-                    {showSchools ? "Hide Schools" : "Show Schools"}
-                </Button>
+                <div className="flex items-center gap-2">
+                    <label
+                        htmlFor="show-schools-toggle"
+                        className="text-sm cursor-pointer select-none"
+                    >
+                        Show Schools
+                    </label>
+                    <Switch
+                        id="show-schools-toggle"
+                        checked={showSchools}
+                        onCheckedChange={setShowSchools}
+                    />
+                </div>
             </div>
             <div className="flex-1 rounded-2xl overflow-hidden border border-slate-200 relative">
                 <Map

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,39 @@
+/***************************************************************
+ *
+ *                /components/ui/switch.tsx
+ *
+ *         Author: Hansini Gundavarapu
+ *           Date: 04/08/2026
+ *
+ *        Summary: shadcn-style Switch component built on
+ *                 @radix-ui/react-switch
+ *
+ **************************************************************/
+
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+    React.ElementRef<typeof SwitchPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+    <SwitchPrimitive.Root
+        className={cn(
+            "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#5DD87A] data-[state=unchecked]:bg-input",
+            className,
+        )}
+        {...props}
+        ref={ref}
+    >
+        <SwitchPrimitive.Thumb
+            className={cn(
+                "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+            )}
+        />
+    </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };


### PR DESCRIPTION
## Issue
<!-- Title and link the issue number here starting with an "#" -->
#155 Design: Hide Schools Toggle

## Who worked on this sprint/bug?
Hansini 

## Features Implemented
<!-- List -->
Replaced the "Hide Schools" / "Show Schools" button on the heatmap with a shadcn Switch toggle component

## New files created
<!-- List, including path -->
<!-- Remember to add headers to your code! -->
src/components/ui/switch.tsx — shadcn-style Switch component built on @radix-ui/react-switch, styled with a green checked state to match the design spec

## Existing files modified
<!-- List, including path -->
<!-- Scroll below to see modified files -->
src/app/map/page.tsx — replaced <Button> with <Switch> + "Show Schools" label; added @radix-ui/react-switch dependency to package.json

## Acceptance Criteria
<!-- Please include the acceptance criteria from the issue here
     and whether or not you completed each requirement -->
Use the shadcn Switch component to add a slider to switch between showing/hiding school icons - done
Ensure functionality remains the same (schools still show/hide on toggle) - done

## Testing: how did you test?
<!-- Please describe how you tested your changes. -->
Ran the app locally and navigated to the heatmap page
Verified the toggle renders in the top right corner
Toggled it on and off to confirm school icons show and hide correctly

## Tag Dan and Shayne
<!-- Also, add us as "Reviewers" on the right sidebar -->
@danglorioso @shaynesidman
