### PR TITLE
Design: add region to school profile pages

### DIFF
--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -365,6 +365,7 @@ export default function SchoolProfilePage() {
                 {/* Info Row */}
                 <SchoolInfoRow
                     town={schoolData.town}
+                    region={schoolData.region}
                     implementationModel={schoolData.implementationModel}
                     firstYear={schoolData.firstYear}
                 />

--- a/src/components/SchoolInfoRow.tsx
+++ b/src/components/SchoolInfoRow.tsx
@@ -9,21 +9,23 @@
  *
  **************************************************************/
 
-import { MapPin, BookOpen, Calendar } from "lucide-react";
+import { MapPinned, MapPin, BookOpen, Calendar } from "lucide-react";
 
 interface SchoolInfoRowProps {
     town: string;
+    region: string;
     implementationModel: string;
     firstYear: string;
 }
 
 export function SchoolInfoRow({
     town,
+    region,
     implementationModel,
     firstYear,
 }: SchoolInfoRowProps) {
     return (
-        <div className="grid grid-cols-3 gap-6">
+        <div className="grid grid-cols-4 gap-6">
             {/* Town */}
             <div className="flex flex-col gap-2 p-4 rounded-lg border border-border">
                 <div className="flex items-center gap-2">
@@ -34,6 +36,19 @@ export function SchoolInfoRow({
                 </div>
                 <span className="text-lg font-semibold text-foreground">
                     {town}, MA
+                </span>
+            </div>
+
+            {/* Region */}
+            <div className="flex flex-col gap-2 p-4 rounded-lg border border-border">
+                <div className="flex items-center gap-2">
+                    <MapPinned className="w-5 h-5" />
+                    <span className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                        Region
+                    </span>
+                </div>
+                <span className="text-lg font-semibold text-foreground">
+                    {region || "Unknown"}
                 </span>
             </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
#102 https://github.com/JumboCode/mhd/issues/102

## Who worked on this sprint/bug?
Cursor agent

## Who did what on this sprint/bug?
Implemented the school profile UI update to include region in the school information cards.

## Features Implemented
- Added a Region card to the school profile info row.
- Wired the school profile page to pass `schoolData.region` into `SchoolInfoRow`.
- Preserved existing cards for Town, Implementation Model, and Data Since.

## New files created
- None.

## Existing files modified
- `src/components/SchoolInfoRow.tsx`
- `src/app/schools/[name]/page.tsx`

## Acceptance Criteria
- Add region to school profile page cards: ✅ Completed.
- Place region with town, instruction model, first year info cards: ✅ Completed.

## Testing: how did you test?
- Verified code changes compile syntactically and props are wired correctly.
- Ran lint/build checks in follow-up validation step.

## Features Not Implemented/Incomplete
- No design-specific visual tweaks beyond adding the new Region card.

## Bugs Discovered
- None during implementation.

## Screenshots:
- Not captured in this run.

## Tag Dan and Shayne
@danglorioso @shaynesidman
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a1473f5-3363-48ca-bc39-e9a9a2289183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a1473f5-3363-48ca-bc39-e9a9a2289183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

