### PR TITLE
Fix backwards custom year range selection on chart page

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -221,12 +221,35 @@ export default function ChartPage() {
         "endYear",
         parseAsInteger.withDefault(2025),
     );
+    const normalizeYearRange = useCallback((start: number, end: number) => {
+        if (start <= end) {
+            return { start, end };
+        }
+
+        return { start: end, end: start };
+    }, []);
+    const updateYearRange = useCallback(
+        (
+            start: number,
+            end: number,
+            options?: { notifyIfSwapped?: boolean },
+        ) => {
+            const normalizedRange = normalizeYearRange(start, end);
+
+            if (options?.notifyIfSwapped && start > end) {
+                toast.info(
+                    "Year range was swapped to keep start year before end year.",
+                );
+            }
+
+            setStartYear(normalizedRange.start);
+            setEndYear(normalizedRange.end);
+        },
+        [normalizeYearRange, setStartYear, setEndYear],
+    );
     const yearRange = useMemo(
-        () => ({
-            start: startYear,
-            end: endYear,
-        }),
-        [startYear, endYear],
+        () => normalizeYearRange(startYear, endYear),
+        [startYear, endYear, normalizeYearRange],
     );
     const [tempYearRange, setTempYearRange] = useState({
         start: startYear,
@@ -459,21 +482,18 @@ export default function ChartPage() {
 
         if (timePeriod === "3y") {
             //return { start: maxYear - 2, end: maxYear };
-            setStartYear(maxYear - 2);
-            setEndYear(maxYear);
+            updateYearRange(maxYear - 2, maxYear);
             return;
         } else if (timePeriod === "5y") {
             //return { start: maxYear - 4, end: maxYear };
-            setStartYear(maxYear - 4);
-            setEndYear(maxYear);
+            updateYearRange(maxYear - 4, maxYear);
             return;
         }
 
         // "all" - use full range
         const minYear = Math.min(...allYears);
-        setStartYear(minYear);
-        setEndYear(maxYear);
-    }, [timePeriod, allProjects]);
+        updateYearRange(minYear, maxYear);
+    }, [timePeriod, allProjects, updateYearRange]);
 
     // Memoize graph dataset calculation to run only when data or filters change
     const graphDataset: ChartDataset[] = useMemo(() => {
@@ -1264,11 +1284,12 @@ export default function ChartPage() {
                                             <Button
                                                 size="sm"
                                                 onClick={() => {
-                                                    setStartYear(
+                                                    updateYearRange(
                                                         tempYearRange.start,
-                                                    );
-                                                    setEndYear(
                                                         tempYearRange.end,
+                                                        {
+                                                            notifyIfSwapped: true,
+                                                        },
                                                     );
                                                     setTimePeriod("custom");
                                                     setYearRangeOpen(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
Fixes #207

## Who worked on this sprint/bug?
- Cursor agent

## Who did what on this sprint/bug?
- Implemented and validated a year-range normalization flow in the chart page custom year selector.

## Features Implemented
- Added centralized year-range normalization so the app always stores `startYear <= endYear`.
- Updated custom range Apply behavior to auto-swap backwards ranges.
- Added an info toast when a backwards range is entered and auto-corrected.
- Reused the same normalization path for preset ranges (`3y`, `5y`, `all`) for consistency.

## New files created
- None

## Existing files modified
- `src/app/chart/page.tsx`

## Acceptance Criteria
- Backwards year selection is not silently accepted. ✅
- Selecting start year greater than end year now auto-corrects by swapping values. ✅
- User receives feedback when swap happens in custom range Apply flow. ✅

## Testing: how did you test?
- Ran `npm run lint` successfully.
- Verified logic path in `chart/page.tsx` ensures `yearRange` is normalized before filtering/chart rendering.

## Features Not Implemented/Incomplete
- No additional inline validation warning UI was added inside the popover; auto-swap + toast was implemented.

## Bugs Discovered
- None during this change.

## Screenshots:
- None

## Tag Dan and Shayne
@danglorioso @shaynesidman
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef54e974-b93b-49a1-8af5-7315480a0f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef54e974-b93b-49a1-8af5-7315480a0f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

