### PR TITLE
Fix issue #208: reject absurd year values

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -24,7 +24,7 @@ import {
 import { standardize, toTitleCase } from "@/lib/string-standardize";
 import { studentRequiredColumns } from "@/lib/required-spreadsheet-columns";
 import { findRegionOf } from "@/lib/region-finder";
-import { yearSchema } from "@/lib/year-validation";
+import { yearSchema, MIN_YEAR, MAX_YEAR } from "@/lib/year-validation";
 
 type RowData = Array<string | number | boolean | null>;
 
@@ -139,7 +139,9 @@ export async function POST(req: NextRequest) {
         const yearResult = yearSchema.safeParse(jsonReq.formYear);
         if (!yearResult.success) {
             return NextResponse.json(
-                { message: "Year must be between 1900 and 2100." },
+                {
+                    message: `Year must be between ${MIN_YEAR} and ${MAX_YEAR}.`,
+                },
                 { status: 400 },
             );
         }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -24,7 +24,7 @@ import {
 import { standardize, toTitleCase } from "@/lib/string-standardize";
 import { studentRequiredColumns } from "@/lib/required-spreadsheet-columns";
 import { findRegionOf } from "@/lib/region-finder";
-import { parseYear } from "@/lib/year-validation";
+import { yearSchema } from "@/lib/year-validation";
 
 type RowData = Array<string | number | boolean | null>;
 
@@ -136,13 +136,14 @@ export async function POST(req: NextRequest) {
     currentProgress = { progress: 0, complete: false };
     try {
         const jsonReq = await req.json();
-        const year = parseYear(jsonReq.formYear);
-        if (year === null) {
+        const yearResult = yearSchema.safeParse(jsonReq.formYear);
+        if (!yearResult.success) {
             return NextResponse.json(
                 { message: "Year must be between 1900 and 2100." },
                 { status: 400 },
             );
         }
+        const year = yearResult.data;
         const rawData: RowData[] = JSON.parse(jsonReq.formData);
         const schoolCoordinates: SchoolCoordinateData[] =
             jsonReq.schoolCoordinates || [];

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -24,6 +24,7 @@ import {
 import { standardize, toTitleCase } from "@/lib/string-standardize";
 import { studentRequiredColumns } from "@/lib/required-spreadsheet-columns";
 import { findRegionOf } from "@/lib/region-finder";
+import { parseYear } from "@/lib/year-validation";
 
 type RowData = Array<string | number | boolean | null>;
 
@@ -135,7 +136,13 @@ export async function POST(req: NextRequest) {
     currentProgress = { progress: 0, complete: false };
     try {
         const jsonReq = await req.json();
-        const year: number = jsonReq.formYear;
+        const year = parseYear(jsonReq.formYear);
+        if (year === null) {
+            return NextResponse.json(
+                { message: "Year must be between 1900 and 2100." },
+                { status: 400 },
+            );
+        }
         const rawData: RowData[] = JSON.parse(jsonReq.formData);
         const schoolCoordinates: SchoolCoordinateData[] =
             jsonReq.schoolCoordinates || [];

--- a/src/components/StudentInfoUpload.tsx
+++ b/src/components/StudentInfoUpload.tsx
@@ -46,7 +46,7 @@ export default function SpreadsheetUpload({
 
             <div className="flex flex-col gap-2">
                 <h2 className="text-base font-medium">Year</h2>
-                <YearInput year={year} setYear={setYear} />
+                <YearInput year={year} onYearChange={setYear} />
             </div>
 
             <div className="flex flex-col gap-2">

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { ChevronLeft, ChevronRight, TriangleAlert } from "lucide-react";
+import { isYearInRange, MAX_YEAR, MIN_YEAR } from "@/lib/year-validation";
 
 type YearInputProps = {
     year?: number | null;
@@ -17,9 +18,6 @@ export default function YearInput({ year, setYear }: YearInputProps) {
         null,
     );
     const currYear = Number(yearStr);
-
-    const MIN_YEAR = 1900;
-    const MAX_YEAR = 2100;
 
     useEffect(() => {
         async function fetchYearsWithData() {
@@ -34,7 +32,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
     }, []);
 
     useEffect(() => {
-        setYearStr(String(year));
+        setYearStr(year === null || year === undefined ? "" : String(year));
     }, [year]);
 
     const hasData = !!currYear && !!yearsWithData?.has(currYear);
@@ -43,15 +41,35 @@ export default function YearInput({ year, setYear }: YearInputProps) {
         const value = e.target.value.replace(/\D/g, "");
         if (value.length > 4) return;
         setYearStr(value);
-        if (value.length === 4) setYear(Number(value));
+        if (value.length === 4) {
+            const parsedYear = Number(value);
+            setYear(isYearInRange(parsedYear) ? parsedYear : null);
+        } else {
+            setYear(null);
+        }
     };
 
     const handleYearBlur = () => {
-        if (yearStr.length > 0 && yearStr.length < 4) {
-            const padded = yearStr.padStart(4, "0");
-            setYearStr(padded);
-            setYear(Number(padded));
+        if (!yearStr) {
+            setYear(null);
+            return;
         }
+
+        const normalizedYear = yearStr.length < 4 ? yearStr.padStart(4, "0") : yearStr;
+        setYearStr(normalizedYear);
+
+        const parsedYear = Number(normalizedYear);
+        if (!isYearInRange(parsedYear)) {
+            setYear(null);
+            return;
+        }
+
+        if (yearStr.length > 0 && yearStr.length < 4) {
+            setYear(parsedYear);
+            return;
+        }
+
+        setYear(parsedYear);
     };
 
     const incrementYear = () => {
@@ -90,6 +108,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
                     <Input
                         type="text"
                         inputMode="numeric"
+                        maxLength={4}
                         id="year"
                         name="Year"
                         value={yearStr}

--- a/src/components/YearInput.tsx
+++ b/src/components/YearInput.tsx
@@ -9,15 +9,14 @@ import { isYearInRange, MAX_YEAR, MIN_YEAR } from "@/lib/year-validation";
 
 type YearInputProps = {
     year?: number | null;
-    setYear: (year: number | null) => void;
+    onYearChange: (year: number | null) => void;
 };
 
-export default function YearInput({ year, setYear }: YearInputProps) {
-    const [yearStr, setYearStr] = useState("");
+export default function YearInput({ year, onYearChange }: YearInputProps) {
+    const [draft, setDraft] = useState<string | null>(null);
     const [yearsWithData, setYearsWithData] = useState<Set<number> | null>(
         null,
     );
-    const currYear = Number(yearStr);
 
     useEffect(() => {
         async function fetchYearsWithData() {
@@ -31,61 +30,44 @@ export default function YearInput({ year, setYear }: YearInputProps) {
         fetchYearsWithData();
     }, []);
 
-    useEffect(() => {
-        setYearStr(year === null || year === undefined ? "" : String(year));
-    }, [year]);
-
-    const hasData = !!currYear && !!yearsWithData?.has(currYear);
+    // Derive display value: use draft while typing, otherwise derive from prop
+    const displayValue = draft ?? (year ? String(year) : "");
+    const displayYear = Number(displayValue);
+    const hasData = !!displayYear && !!yearsWithData?.has(displayYear);
 
     const handleYearInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value.replace(/\D/g, "");
         if (value.length > 4) return;
-        setYearStr(value);
+        setDraft(value);
         if (value.length === 4) {
             const parsedYear = Number(value);
-            setYear(isYearInRange(parsedYear) ? parsedYear : null);
+            onYearChange(isYearInRange(parsedYear) ? parsedYear : null);
+            setDraft(null);
         } else {
-            setYear(null);
+            onYearChange(null);
         }
     };
 
     const handleYearBlur = () => {
-        if (!yearStr) {
-            setYear(null);
+        if (draft === null) return;
+        if (!draft) {
+            onYearChange(null);
+            setDraft(null);
             return;
         }
 
-        const normalizedYear = yearStr.length < 4 ? yearStr.padStart(4, "0") : yearStr;
-        setYearStr(normalizedYear);
-
-        const parsedYear = Number(normalizedYear);
-        if (!isYearInRange(parsedYear)) {
-            setYear(null);
-            return;
-        }
-
-        if (yearStr.length > 0 && yearStr.length < 4) {
-            setYear(parsedYear);
-            return;
-        }
-
-        setYear(parsedYear);
+        const normalized = draft.padStart(4, "0");
+        const parsedYear = Number(normalized);
+        onYearChange(isYearInRange(parsedYear) ? parsedYear : null);
+        setDraft(null);
     };
 
     const incrementYear = () => {
-        if (year && currYear < MAX_YEAR) {
-            const newYear = currYear + 1;
-            setYear(newYear);
-            setYearStr(String(newYear));
-        }
+        if (year && year < MAX_YEAR) onYearChange(year + 1);
     };
 
     const decrementYear = () => {
-        if (year && currYear > MIN_YEAR) {
-            const newYear = currYear - 1;
-            setYear(newYear);
-            setYearStr(String(newYear));
-        }
+        if (year && year > MIN_YEAR) onYearChange(year - 1);
     };
 
     return (
@@ -100,7 +82,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
                 </Button>
 
                 <div className="flex items-center justify-center gap-1.5 px-2 w-[100px]">
-                    {yearsWithData && yearStr && (
+                    {yearsWithData && displayValue && (
                         <div
                             className={`h-2 w-2 rounded-full shrink-0 ${hasData ? "bg-green-500" : "bg-red-500"}`}
                         />
@@ -111,7 +93,7 @@ export default function YearInput({ year, setYear }: YearInputProps) {
                         maxLength={4}
                         id="year"
                         name="Year"
-                        value={yearStr}
+                        value={displayValue}
                         onChange={handleYearInput}
                         onBlur={handleYearBlur}
                         className="h-9 w-[52px] p-0 text-center rounded-none border-0 shadow-none focus-visible:ring-0 bg-background [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -129,8 +111,8 @@ export default function YearInput({ year, setYear }: YearInputProps) {
             {hasData && (
                 <p className="flex items-center gap-1.5 text-sm text-amber-600 dark:text-amber-400">
                     <TriangleAlert className="h-4 w-4 shrink-0" />
-                    Data already exists for {currYear}. Uploading will overwrite
-                    it.
+                    Data already exists for {displayYear}. Uploading will
+                    overwrite it.
                 </p>
             )}
         </div>

--- a/src/lib/year-validation.ts
+++ b/src/lib/year-validation.ts
@@ -3,13 +3,8 @@ import { z } from "zod";
 export const MIN_YEAR = 1900;
 export const MAX_YEAR = 2100;
 
-const yearSchema = z.coerce.number().int().min(MIN_YEAR).max(MAX_YEAR);
+export const yearSchema = z.coerce.number().int().min(MIN_YEAR).max(MAX_YEAR);
 
 export function isYearInRange(year: number): boolean {
     return yearSchema.safeParse(year).success;
-}
-
-export function parseYear(value: unknown): number | null {
-    const parsed = yearSchema.safeParse(value);
-    return parsed.success ? parsed.data : null;
 }

--- a/src/lib/year-validation.ts
+++ b/src/lib/year-validation.ts
@@ -1,17 +1,15 @@
+import { z } from "zod";
+
 export const MIN_YEAR = 1900;
 export const MAX_YEAR = 2100;
 
+const yearSchema = z.coerce.number().int().min(MIN_YEAR).max(MAX_YEAR);
+
 export function isYearInRange(year: number): boolean {
-    return Number.isInteger(year) && year >= MIN_YEAR && year <= MAX_YEAR;
+    return yearSchema.safeParse(year).success;
 }
 
 export function parseYear(value: unknown): number | null {
-    const numericValue =
-        typeof value === "number"
-            ? value
-            : typeof value === "string"
-              ? Number(value.trim())
-              : Number.NaN;
-
-    return isYearInRange(numericValue) ? numericValue : null;
+    const parsed = yearSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
 }

--- a/src/lib/year-validation.ts
+++ b/src/lib/year-validation.ts
@@ -1,0 +1,17 @@
+export const MIN_YEAR = 1900;
+export const MAX_YEAR = 2100;
+
+export function isYearInRange(year: number): boolean {
+    return Number.isInteger(year) && year >= MIN_YEAR && year <= MAX_YEAR;
+}
+
+export function parseYear(value: unknown): number | null {
+    const numericValue =
+        typeof value === "number"
+            ? value
+            : typeof value === "string"
+              ? Number(value.trim())
+              : Number.NaN;
+
+    return isYearInRange(numericValue) ? numericValue : null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
#208 https://github.com/JumboCode/mhd/issues/208

## Who worked on this sprint/bug?
Cursor agent

## Who did what on this sprint/bug?
Implemented year validation updates across upload entry points and API handling, then incorporated review feedback to use Zod for year parsing/validation.

## Features Implemented
- Added shared year validation helpers (`MIN_YEAR=1900`, `MAX_YEAR=2100`).
- Refactored year parsing/validation to use a Zod schema (`z.coerce.number().int().min(...).max(...)`) for better type safety and readability.
- Updated upload year input handling to enforce numeric 4-digit input and only commit in-range years.
- Added backend validation in `/api/upload` to reject out-of-range or malformed years with HTTP 400.

## New files created
- `src/lib/year-validation.ts`

## Existing files modified
- `src/components/YearInput.tsx`
- `src/app/api/upload/route.ts`

## Acceptance Criteria
- Input should validate reasonable year range (e.g., 1900-2100) or limit character count: **Completed**
  - Character count limited to 4 in the year input.
  - Year range validated to 1900-2100 in UI logic and server API.

## Testing: how did you test?
- Ran project lint checks after implementation.
- Re-ran lint after Zod refactor.
- Verified ESLint passes for changed files.

## Features Not Implemented/Incomplete
- Did not add additional error messaging UI text around invalid range; current behavior prevents progression by clearing invalid year selection.

## Bugs Discovered
- None beyond issue #208.

## Screenshots:
- N/A

## Tag Dan and Shayne
@danglorioso @shaynesidman
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30c9121d-4728-4c7c-952c-edf2a29580d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30c9121d-4728-4c7c-952c-edf2a29580d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

