### PR TITLE
Add Zod validation across API routes (issue #209)

### DIFF
--- a/src/app/api/delete-year/route.ts
+++ b/src/app/api/delete-year/route.ts
@@ -18,6 +18,11 @@ import {
     yearMetadata,
 } from "@/lib/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+const deleteYearQuerySchema = z.object({
+    year: z.coerce.number().int().positive(),
+});
 
 /**
  * Deletes all data for the specified year.
@@ -28,15 +33,16 @@ import { eq } from "drizzle-orm";
 export async function DELETE(req: NextRequest) {
     try {
         const { searchParams } = new URL(req.url);
-        const yearString = searchParams.get("year");
-        const currentYear = Number(yearString);
-
-        if (!currentYear || isNaN(currentYear)) {
+        const parsedQuery = deleteYearQuerySchema.safeParse({
+            year: searchParams.get("year"),
+        });
+        if (!parsedQuery.success) {
             return NextResponse.json(
                 { message: "Invalid year parameter" },
                 { status: 400 },
             );
         }
+        const currentYear = parsedQuery.data.year;
 
         // Delete rows for the specified year
         await db.delete(projects).where(eq(projects.year, currentYear));

--- a/src/app/api/heat-layer/route.ts
+++ b/src/app/api/heat-layer/route.ts
@@ -13,19 +13,25 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { schools, projects, yearlyTeacherParticipation } from "@/lib/schema";
 import { eq, isNotNull } from "drizzle-orm";
+import { z } from "zod";
+
+const heatLayerQuerySchema = z.object({
+    year: z.coerce.number().int().positive(),
+});
 
 export async function GET(req: NextRequest) {
     try {
         const { searchParams } = new URL(req.url);
-        const yearString = searchParams.get("year");
-        const currentYear = Number(yearString);
-
-        if (!currentYear || isNaN(currentYear)) {
+        const parsedQuery = heatLayerQuerySchema.safeParse({
+            year: searchParams.get("year"),
+        });
+        if (!parsedQuery.success) {
             return NextResponse.json(
                 { message: "Invalid year parameter" },
                 { status: 400 },
             );
         }
+        const currentYear = parsedQuery.data.year;
 
         // Fetch all schools with latitude and longitude
         const schoolsPerYear = await db

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -17,83 +17,68 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { projects, yearMetadata } from "@/lib/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+const projectParamsSchema = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const projectPatchBodySchema = z
+    .object({
+        title: z.string().trim().min(1).optional(),
+        category: z.string().trim().min(1).optional(),
+        categoryId: z.string().trim().min(1).optional(),
+        division: z.string().trim().min(1).optional(),
+        teamProject: z
+            .union([z.boolean(), z.literal("true"), z.literal("false")])
+            .transform((value) => value === true || value === "true")
+            .optional(),
+        numStudents: z.coerce.number().int().min(1).optional(),
+    })
+    .strict();
+
+type ProjectUpdates = Partial<{
+    title: string;
+    category: string;
+    categoryId: string;
+    division: string;
+    teamProject: boolean;
+    numStudents: number;
+}>;
 
 export async function PATCH(
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
 ) {
     try {
-        const { id } = await params;
-        // Parse and validate the project ID from the URL
-        const numericId = Number(id);
-
-        if (isNaN(numericId) || !Number.isInteger(numericId)) {
+        const parsedParams = projectParamsSchema.safeParse(await params);
+        if (!parsedParams.success) {
             return NextResponse.json(
                 { error: "Invalid project ID" },
                 { status: 400 },
             );
         }
+        const numericId = parsedParams.data.id;
 
-        const body = await req.json();
+        const parsedBody = projectPatchBodySchema.safeParse(await req.json());
+        if (!parsedBody.success) {
+            return NextResponse.json(
+                {
+                    error:
+                        parsedBody.error.issues[0]?.message ??
+                        "Invalid request body",
+                },
+                { status: 400 },
+            );
+        }
 
         // Build an updates object containing only the fields present in the body.
         // This ensures we never overwrite fields the caller didn't intend to change.
-        const updates: Partial<{
-            title: string;
-            category: string;
-            categoryId: string;
-            division: string;
-            teamProject: boolean;
-            numStudents: number;
-        }> = {};
-
-        // Validate and coerce each allowed field to its correct DB type
-        if ("title" in body) {
-            const val = String(body.title).trim();
-            if (!val)
-                return NextResponse.json(
-                    { error: "title cannot be empty" },
-                    { status: 400 },
-                );
-            updates.title = val;
-        }
-        if ("category" in body) {
-            const val = String(body.category).trim();
-            if (!val)
-                return NextResponse.json(
-                    { error: "category cannot be empty" },
-                    { status: 400 },
-                );
-            updates.category = val;
-        }
-        if ("categoryId" in body) {
-            updates.categoryId = String(body.categoryId).trim();
-        }
-        if ("division" in body) {
-            const val = String(body.division).trim();
-            if (!val)
-                return NextResponse.json(
-                    { error: "division cannot be empty" },
-                    { status: 400 },
-                );
-            updates.division = val;
-        }
-        if ("teamProject" in body) {
-            // Accept both boolean true and the string "true" from JSON
-            updates.teamProject =
-                body.teamProject === true || body.teamProject === "true";
-        }
-        if ("numStudents" in body) {
-            // Must be a positive integer — reject decimals, negatives, and NaN
-            const val = Number(body.numStudents);
-            if (isNaN(val) || !Number.isInteger(val) || val < 1) {
-                return NextResponse.json(
-                    { error: "numStudents must be a positive integer" },
-                    { status: 400 },
-                );
-            }
-            updates.numStudents = val;
-        }
+        const updates = Object.fromEntries(
+            Object.entries(parsedBody.data).filter(
+                ([, value]) => value !== undefined,
+            ),
+        ) as ProjectUpdates;
 
         // Reject the request if the body contained no recognized fields
         if (Object.keys(updates).length === 0) {

--- a/src/app/api/schools/[name]/route.ts
+++ b/src/app/api/schools/[name]/route.ts
@@ -21,12 +21,34 @@ import {
 } from "@/lib/schema";
 import { eq, sql, and, sum } from "drizzle-orm";
 import { findRegionOf } from "@/lib/region-finder";
+import { z } from "zod";
 
 type YearlySchoolFields = {
     division?: string[];
     implementationModel?: string;
     schoolType?: string;
 };
+
+const schoolNameParamsSchema = z.object({
+    name: z.string().trim().min(1),
+});
+
+const schoolGetQuerySchema = z.object({
+    year: z.coerce.number().int().positive(),
+});
+
+const schoolPatchBodySchema = z
+    .object({
+        latitude: z.number().finite().optional(),
+        longitude: z.number().finite().optional(),
+        name: z.string().trim().min(1).optional(),
+        city: z.string().trim().min(1).optional(),
+        implementationModel: z.string().optional(),
+        schoolType: z.string().optional(),
+        division: z.array(z.string()).optional(),
+        year: z.coerce.number().int().positive().optional(),
+    })
+    .strict();
 
 async function upsertYearlySchoolData(
     schoolId: number,
@@ -58,9 +80,27 @@ export async function PATCH(
     { params }: { params: Promise<{ name: string }> },
 ) {
     try {
-        const { name } = await params;
+        const parsedParams = schoolNameParamsSchema.safeParse(await params);
+        if (!parsedParams.success) {
+            return NextResponse.json(
+                { error: "Invalid school name" },
+                { status: 400 },
+            );
+        }
+        const name = parsedParams.data.name;
 
-        const body = await req.json();
+        const parsedBody = schoolPatchBodySchema.safeParse(await req.json());
+        if (!parsedBody.success) {
+            return NextResponse.json(
+                {
+                    error:
+                        parsedBody.error.issues[0]?.message ??
+                        "Invalid request body",
+                },
+                { status: 400 },
+            );
+        }
+        const body = parsedBody.data;
         const {
             latitude,
             longitude,
@@ -121,15 +161,6 @@ export async function PATCH(
 
         // Handle division update
         if (division !== undefined) {
-            if (
-                !Array.isArray(division) ||
-                division.some((d: unknown) => typeof d !== "string")
-            ) {
-                return NextResponse.json(
-                    { error: "division must be an array of strings" },
-                    { status: 400 },
-                );
-            }
             if (!year) {
                 return NextResponse.json(
                     { error: "year is required for division updates" },
@@ -144,12 +175,6 @@ export async function PATCH(
 
         // Handle implementation model update
         if (implementationModel !== undefined) {
-            if (typeof implementationModel !== "string") {
-                return NextResponse.json(
-                    { error: "implementationModel must be a string" },
-                    { status: 400 },
-                );
-            }
             if (!year) {
                 return NextResponse.json(
                     {
@@ -168,12 +193,6 @@ export async function PATCH(
 
         // Handle schoolType update
         if (schoolType !== undefined) {
-            if (typeof schoolType !== "string") {
-                return NextResponse.json(
-                    { error: "schoolType must be a string" },
-                    { status: 400 },
-                );
-            }
             if (!year) {
                 return NextResponse.json(
                     { error: "year is required for schoolType updates" },
@@ -227,8 +246,24 @@ export async function GET(
 ) {
     try {
         const { searchParams } = new URL(req.url);
-        const year = Number(searchParams.get("year"));
-        const { name } = await params;
+        const parsedQuery = schoolGetQuerySchema.safeParse({
+            year: searchParams.get("year"),
+        });
+        if (!parsedQuery.success) {
+            return NextResponse.json(
+                { error: "Invalid year query parameter" },
+                { status: 400 },
+            );
+        }
+        const year = parsedQuery.data.year;
+        const parsedParams = schoolNameParamsSchema.safeParse(await params);
+        if (!parsedParams.success) {
+            return NextResponse.json(
+                { error: "Invalid school name" },
+                { status: 400 },
+            );
+        }
+        const name = parsedParams.data.name;
 
         // Match on standardized name
         const schoolResult = await db

--- a/src/app/api/schools/route.ts
+++ b/src/app/api/schools/route.ts
@@ -18,6 +18,23 @@ import {
     yearlyTeacherParticipation,
 } from "@/lib/schema";
 import { and, count, eq, sum } from "drizzle-orm";
+import { z } from "zod";
+
+const schoolsQuerySchema = z
+    .object({
+        list: z.enum(["true", "false"]).optional(),
+        gateway: z.enum(["true", "false"]).optional(),
+        year: z.coerce.number().int().positive().optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.list !== "true" && data.year === undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "year is required when list is not true",
+                path: ["year"],
+            });
+        }
+    });
 
 function percentageChange(curr: number, past: number) {
     return past !== 0 ? Math.round(((curr - past) / past) * 100) : undefined;
@@ -26,11 +43,22 @@ function percentageChange(curr: number, past: number) {
 export async function GET(req: NextRequest) {
     try {
         const { searchParams } = new URL(req.url);
+        const parsedQuery = schoolsQuerySchema.safeParse({
+            list: searchParams.get("list") ?? undefined,
+            gateway: searchParams.get("gateway") ?? undefined,
+            year: searchParams.get("year") ?? undefined,
+        });
+        if (!parsedQuery.success) {
+            return NextResponse.json(
+                { message: "Invalid query parameters" },
+                { status: 400 },
+            );
+        }
+        const query = parsedQuery.data;
 
         // Lightweight list mode: school info for all schools
-        if (searchParams.get("list") === "true") {
-            const gatewayParam = searchParams.get("gateway");
-            const isGateway = gatewayParam === "true";
+        if (query.list === "true") {
+            const isGateway = query.gateway === "true";
 
             const baseQuery = db
                 .select({
@@ -50,15 +78,7 @@ export async function GET(req: NextRequest) {
             return NextResponse.json(allSchools);
         }
 
-        const yearString = searchParams.get("year");
-        const currentYear = Number(yearString);
-
-        if (!currentYear || isNaN(currentYear)) {
-            return NextResponse.json(
-                { message: "Invalid year parameter" },
-                { status: 400 },
-            );
-        }
+        const currentYear = query.year!;
 
         // Fetch all schools with yearly data for the requested year
         const allSchools = await db

--- a/src/app/api/teachers/[id]/route.ts
+++ b/src/app/api/teachers/[id]/route.ts
@@ -17,54 +17,53 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { teachers, projects, yearMetadata } from "@/lib/schema";
 import { eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+
+const teacherParamsSchema = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const teacherPatchBodySchema = z
+    .object({
+        name: z.string().trim().min(1).optional(),
+        email: z.string().trim().email().min(1).optional(),
+    })
+    .strict();
+
+type TeacherUpdates = Partial<{ name: string; email: string }>;
 
 export async function PATCH(
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
 ) {
     try {
-        const { id } = await params;
-        // Parse and validate the teacher ID from the URL
-        const numericId = Number(id);
-
-        if (isNaN(numericId) || !Number.isInteger(numericId)) {
+        const parsedParams = teacherParamsSchema.safeParse(await params);
+        if (!parsedParams.success) {
             return NextResponse.json(
                 { error: "Invalid teacher ID" },
                 { status: 400 },
             );
         }
+        const numericId = parsedParams.data.id;
 
-        const body = await req.json();
+        const parsedBody = teacherPatchBodySchema.safeParse(await req.json());
+        if (!parsedBody.success) {
+            return NextResponse.json(
+                {
+                    error:
+                        parsedBody.error.issues[0]?.message ??
+                        "Invalid request body",
+                },
+                { status: 400 },
+            );
+        }
 
         // Build updates object with only the fields present in the request body
-        const updates: Partial<{ name: string; email: string }> = {};
-
-        if ("name" in body) {
-            const val = String(body.name).trim();
-            if (!val)
-                return NextResponse.json(
-                    { error: "name cannot be empty" },
-                    { status: 400 },
-                );
-            updates.name = val;
-        }
-        if ("email" in body) {
-            const val = String(body.email).trim();
-            if (!val)
-                return NextResponse.json(
-                    { error: "email cannot be empty" },
-                    { status: 400 },
-                );
-            // Validate basic email format before writing to the database
-            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-            if (!emailRegex.test(val)) {
-                return NextResponse.json(
-                    { error: "Invalid email format" },
-                    { status: 400 },
-                );
-            }
-            updates.email = val;
-        }
+        const updates = Object.fromEntries(
+            Object.entries(parsedBody.data).filter(
+                ([, value]) => value !== undefined,
+            ),
+        ) as TeacherUpdates;
 
         // Reject the request if the body contained no recognized fields
         if (Object.keys(updates).length === 0) {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -24,6 +24,7 @@ import {
 import { standardize, toTitleCase } from "@/lib/string-standardize";
 import { studentRequiredColumns } from "@/lib/required-spreadsheet-columns";
 import { findRegionOf } from "@/lib/region-finder";
+import { z } from "zod";
 
 type RowData = Array<string | number | boolean | null>;
 
@@ -32,6 +33,30 @@ type SchoolCoordinateData = {
     lat: number | null;
     long: number | null;
 };
+
+const spreadsheetCellSchema = z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+]);
+
+const rowDataSchema = z.array(spreadsheetCellSchema);
+
+const uploadSchoolCoordinateSchema = z.object({
+    schoolId: z.string().trim().min(1),
+    lat: z.number().nullable(),
+    long: z.number().nullable(),
+});
+
+const uploadRequestSchema = z
+    .object({
+        formYear: z.coerce.number().int().positive(),
+        formData: z.string().min(1),
+        schoolCoordinates: z.array(uploadSchoolCoordinateSchema).optional(),
+        schoolInfoData: z.string().optional(),
+    })
+    .strict();
 
 let currentProgress = {
     progress: 0,
@@ -134,16 +159,72 @@ function buildSchoolInfoMap(rawData: RowData[]): Map<string, SchoolInfoEntry> {
 export async function POST(req: NextRequest) {
     currentProgress = { progress: 0, complete: false };
     try {
-        const jsonReq = await req.json();
-        const year: number = jsonReq.formYear;
-        const rawData: RowData[] = JSON.parse(jsonReq.formData);
+        const parsedRequest = uploadRequestSchema.safeParse(await req.json());
+        if (!parsedRequest.success) {
+            return NextResponse.json(
+                {
+                    message:
+                        parsedRequest.error.issues[0]?.message ??
+                        "Invalid upload payload",
+                },
+                { status: 400 },
+            );
+        }
+        const requestBody = parsedRequest.data;
+        const year: number = requestBody.formYear;
+
+        const parsedFormData = z
+            .string()
+            .transform((value, ctx) => {
+                try {
+                    return JSON.parse(value);
+                } catch {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: "formData must be valid JSON",
+                    });
+                    return z.NEVER;
+                }
+            })
+            .pipe(z.array(rowDataSchema))
+            .safeParse(requestBody.formData);
+        if (!parsedFormData.success) {
+            return NextResponse.json(
+                { message: parsedFormData.error.issues[0]?.message },
+                { status: 400 },
+            );
+        }
+        const rawData: RowData[] = parsedFormData.data;
         const schoolCoordinates: SchoolCoordinateData[] =
-            jsonReq.schoolCoordinates || [];
+            requestBody.schoolCoordinates || [];
 
         // Parse the school info spreadsheet if provided
+        const parsedSchoolInfoData = requestBody.schoolInfoData
+            ? z
+                  .string()
+                  .transform((value, ctx) => {
+                      try {
+                          return JSON.parse(value);
+                      } catch {
+                          ctx.addIssue({
+                              code: z.ZodIssueCode.custom,
+                              message: "schoolInfoData must be valid JSON",
+                          });
+                          return z.NEVER;
+                      }
+                  })
+                  .pipe(z.array(rowDataSchema))
+                  .safeParse(requestBody.schoolInfoData)
+            : null;
+        if (parsedSchoolInfoData && !parsedSchoolInfoData.success) {
+            return NextResponse.json(
+                { message: parsedSchoolInfoData.error.issues[0]?.message },
+                { status: 400 },
+            );
+        }
         const schoolInfoMap: Map<string, SchoolInfoEntry> =
-            jsonReq.schoolInfoData
-                ? buildSchoolInfoMap(JSON.parse(jsonReq.schoolInfoData))
+            parsedSchoolInfoData?.success
+                ? buildSchoolInfoMap(parsedSchoolInfoData.data)
                 : new Map();
 
         // Build coordinates lookup

--- a/src/app/api/yearly-totals/route.ts
+++ b/src/app/api/yearly-totals/route.ts
@@ -1,19 +1,25 @@
 import { NextResponse } from "next/server";
 import { getYearlyStats, getAllYearsStats } from "@/lib/yearlyTotals";
+import { z } from "zod";
+
+const yearlyTotalsQuerySchema = z.object({
+    year: z.coerce.number().int().positive(),
+});
 
 export async function GET(req: Request) {
     try {
         const { searchParams } = new URL(req.url);
-        const year: string | null = searchParams.get("year");
-
-        if (year === null) {
+        const parsedQuery = yearlyTotalsQuerySchema.safeParse({
+            year: searchParams.get("year"),
+        });
+        if (!parsedQuery.success) {
             return NextResponse.json(
-                { error: "Expected year but received null" },
+                { error: "Invalid year query parameter" },
                 { status: 400 },
             );
         }
 
-        const yearNum: number = parseInt(year);
+        const yearNum = parsedQuery.data.year;
         const [yearlyStats, allYearsStats] = await Promise.all([
             getYearlyStats(yearNum),
             getAllYearsStats(),

--- a/src/app/api/years-with-data/route.ts
+++ b/src/app/api/years-with-data/route.ts
@@ -13,11 +13,27 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { yearlySchoolParticipation, yearMetadata, schools } from "@/lib/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+const yearsWithDataQuerySchema = z.object({
+    school: z.string().trim().min(1).optional(),
+    simple: z.enum(["true", "false"]).optional(),
+});
 
 export async function GET(req: Request) {
     try {
         const { searchParams } = new URL(req.url);
-        const schoolParam = searchParams.get("school");
+        const parsedQuery = yearsWithDataQuerySchema.safeParse({
+            school: searchParams.get("school") ?? undefined,
+            simple: searchParams.get("simple") ?? undefined,
+        });
+        if (!parsedQuery.success) {
+            return NextResponse.json(
+                { error: "Invalid query parameters" },
+                { status: 400 },
+            );
+        }
+        const schoolParam = parsedQuery.data.school;
 
         // If a school standardized name is provided, return only years that
         // school participated in (used by the school profile page).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
#209 https://github.com/JumboCode/mhd/issues/209

## Who worked on this sprint/bug?
Cursor cloud agent

## Who did what on this sprint/bug?
Implemented server-side Zod validation for all routes listed in the issue, replacing manual validation logic where needed and preserving existing route behavior.

## Features Implemented
- Added Zod validation for `/api/upload` POST payload, including `formYear`, `formData`, `schoolCoordinates`, and `schoolInfoData` JSON parsing/shape checks.
- Added Zod validation for PATCH routes:
  - `/api/projects/[id]` (`id`, `title`, `category`, `categoryId`, `division`, `teamProject`, `numStudents`)
  - `/api/teachers/[id]` (`id`, `name`, `email`)
  - `/api/schools/[name]` (`name` param, `year` for yearly fields, and body fields for location/name/city/metadata updates)
- Added Zod validation for GET query routes:
  - `/api/schools` (`year`, `list`, `gateway`)
  - `/api/schools/[name]` (`year`)
  - `/api/heat-layer` (corresponding to heatmap endpoint in current codebase) (`year`)
  - `/api/years-with-data` (`school`, `simple`)
  - `/api/yearly-totals` (`year`)
- Added Zod validation for DELETE route:
  - `/api/delete-year` (corresponding to year delete endpoint in current codebase) (`year`)

## New files created
- None

## Existing files modified
- `src/app/api/upload/route.ts`
- `src/app/api/projects/[id]/route.ts`
- `src/app/api/teachers/[id]/route.ts`
- `src/app/api/schools/[name]/route.ts`
- `src/app/api/schools/route.ts`
- `src/app/api/heat-layer/route.ts`
- `src/app/api/years-with-data/route.ts`
- `src/app/api/yearly-totals/route.ts`
- `src/app/api/delete-year/route.ts`

## Acceptance Criteria
- Add server-side validation using Zod for all listed API routes: completed.
- Convert PATCH routes with manual validation to Zod-based validation: completed.
- Validate required query/body/route params to prevent bypass of client-side constraints: completed.

## Testing: how did you test?
- `npm run lint`
- Verified API route handlers compile with updated Zod schemas and existing logic paths retained.

## Features Not Implemented/Incomplete
- No route renaming was performed; validation was applied to the current codebase routes (`/api/heat-layer`, `/api/delete-year`) that correspond functionally to issue targets.

## Bugs Discovered
- None during implementation.

## Screenshots:
- N/A

## Tag Dan and Shayne
@danglorioso @shaynesidman
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6117e5a-4d2e-4d35-9118-c15c1876c840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6117e5a-4d2e-4d35-9118-c15c1876c840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

