### PR TITLE
startYear, endYear, measuredAs, and groupBy now show up in URL by default

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -208,6 +208,8 @@ export default function ChartPage() {
         null,
     );
 
+    const currentYear: number = new Date().getFullYear();
+
     // Setting hooks
     const [timePeriod, setTimePeriod] = useQueryState(
         "period",
@@ -215,12 +217,20 @@ export default function ChartPage() {
     );
     const [startYear, setStartYear] = useQueryState(
         "startYear",
-        parseAsInteger.withDefault(2020),
+        parseAsInteger
+            .withDefault(currentYear - 5)
+            .withOptions({ clearOnDefault: false }),
     );
     const [endYear, setEndYear] = useQueryState(
         "endYear",
-        parseAsInteger.withDefault(2025),
+        parseAsInteger
+            .withDefault(currentYear)
+            .withOptions({ clearOnDefault: false }),
     );
+    useEffect(() => {
+        setStartYear((v) => v);
+        setEndYear((v) => v);
+    }, []);
     const normalizeYearRange = useCallback((start: number, end: number) => {
         if (start <= end) {
             return { start, end };
@@ -259,7 +269,7 @@ export default function ChartPage() {
 
     const [chartType, setChartType] = useQueryState(
         "type",
-        parseAsString.withDefault("bar"),
+        parseAsString.withDefault("bar").withOptions({ clearOnDefault: false }),
     );
     const slideDirection = useRef(0);
     const handleChartTypeChange = useCallback(

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -227,10 +227,6 @@ export default function ChartPage() {
             .withDefault(currentYear)
             .withOptions({ clearOnDefault: false }),
     );
-    useEffect(() => {
-        setStartYear((v) => v);
-        setEndYear((v) => v);
-    }, []);
     const normalizeYearRange = useCallback((start: number, end: number) => {
         if (start <= end) {
             return { start, end };
@@ -291,12 +287,17 @@ export default function ChartPage() {
     // Filter hooks
     const [groupBy, setGroupBy] = useQueryState(
         "groupBy",
-        parseAsString.withDefault("none"),
+        parseAsString
+            .withDefault("none")
+            .withOptions({ clearOnDefault: false }),
     );
     const [measuredAs, setMeasuredAs] = useQueryState(
         "measuredAs",
-        parseAsString.withDefault("total-school-count"),
+        parseAsString
+            .withDefault("total-school-count")
+            .withOptions({ clearOnDefault: false }),
     );
+
     const [selectedSchools, setSelectedSchools] = useQueryState(
         "schools",
         parseAsArrayOf(parseAsString).withDefault([]),

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -132,7 +132,9 @@ function HeatMapPage() {
     // totalStudents | totalProjects | totalTeachers (lowercase in URL)
     const [rawMetric, setRawMetric] = useQueryState(
         "metric",
-        parseAsString.withDefault("projects"),
+        parseAsString
+            .withDefault("projects")
+            .withOptions({ clearOnDefault: false }),
     );
 
     // gateway school toggle variable
@@ -143,7 +145,9 @@ function HeatMapPage() {
 
     const [rawRegionView, setRegionView] = useQueryState(
         "regionView",
-        parseAsString.withDefault("default"),
+        parseAsString
+            .withDefault("default")
+            .withOptions({ clearOnDefault: false }),
     );
     const regionView = rawRegionView.toLowerCase();
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -111,6 +111,8 @@ export default function Sidebar() {
         });
     };
 
+    const currentYear: number = new Date().getFullYear();
+
     const sections = [
         {
             title: "ANALYSIS",
@@ -121,7 +123,7 @@ export default function Sidebar() {
                     icon: <Map size={20} />,
                 },
                 {
-                    href: "/chart",
+                    href: `/chart?startYear=${currentYear - 5}&endYear=${currentYear}&measuredAs=total-school-count&groupBy=none&type=bar`,
                     label: "Chart",
                     icon: <BarChart3 size={20} />,
                 },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -118,7 +118,7 @@ export default function Sidebar() {
             title: "ANALYSIS",
             items: [
                 {
-                    href: "/map",
+                    href: "/map?metric=projects&regionView=default",
                     label: "Map",
                     icon: <Map size={20} />,
                 },


### PR DESCRIPTION
## Issue

#197 

## Who worked on this sprint/bug?

Anne Wu

## Features Implemented

startYear, endYear, measuredAs, and groupBy now show up in URL for the graph page by default

## Existing files modified

/src/app/chart/page.tsx

## Tag Dan and Shayne

<!-- Also, add us as "Reviewers" on the right sidebar -->

@danglorioso @shaynesidman

<!-- Finally, tag your PR with the appropriate tags on the right sidebar -->
<!-- Including selecting your Issue in the "Development" section -->
<!-- And include you and your partner as "Assignees" -->
