### PR TITLE
Bug: clicking line charts in overview page links to bar charts when clicked on

### DIFF
--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -218,6 +218,9 @@ export default function SchoolProfilePage() {
         year !== null
             ? `/chart?type=line&startYear=${year - 5}&endYear=${year}&measuredAs=total-student-count&schools=${encodeURIComponent(schoolData?.name ?? "")}`
             : "#";
+    const projectsChartHref = `/chart?measuredAs=total-project-count&type=line&schools=${encodeURIComponent(schoolData?.name ?? "")}`;
+    const teachersChartHref = `/chart?measuredAs=total-teacher-count&type=line&schools=${encodeURIComponent(schoolData?.name ?? "")}`;
+    const studentsChartHref = `/chart?measuredAs=total-student-count&type=line&schools=${encodeURIComponent(schoolData?.name ?? "")}`;
 
     // Calculate sparkline data arrays from allYearsData
     const projectsSparkline = allYearsData.map((d) =>
@@ -392,6 +395,7 @@ export default function SchoolProfilePage() {
                         percentChange={projectsPercentChange}
                         showTrend={true}
                         variant="with-aspect"
+                        href={projectsChartHref}
                     />
                     <StatCard
                         label={ENTITY_CONFIG.teachers.label}
@@ -404,6 +408,7 @@ export default function SchoolProfilePage() {
                         percentChange={teachersPercentChange}
                         showTrend={true}
                         variant="with-aspect"
+                        href={teachersChartHref}
                     />
                     <StatCard
                         label={ENTITY_CONFIG.students.label}
@@ -416,6 +421,7 @@ export default function SchoolProfilePage() {
                         percentChange={studentsPercentChange}
                         showTrend={true}
                         variant="with-aspect"
+                        href={studentsChartHref}
                     />
                 </div>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -234,7 +234,7 @@ export default function Dashboard() {
                                 percentChanges?.projects ?? undefined
                             }
                             showTrend={true}
-                            href="/chart?measuredAs=total-project-count"
+                            href="/chart?measuredAs=total-project-count&type=line"
                         />
                         <StatCard
                             label={ENTITY_CONFIG.teachers.label}
@@ -248,7 +248,7 @@ export default function Dashboard() {
                                 percentChanges?.teachers ?? undefined
                             }
                             showTrend={true}
-                            href="/chart?measuredAs=total-teacher-count"
+                            href="/chart?measuredAs=total-teacher-count&type=line"
                         />
                         <StatCard
                             label={ENTITY_CONFIG.students.label}
@@ -262,7 +262,7 @@ export default function Dashboard() {
                                 percentChanges?.students ?? undefined
                             }
                             showTrend={true}
-                            href="/chart?measuredAs=total-student-count"
+                            href="/chart?measuredAs=total-student-count&type=line"
                         />
                         <StatCard
                             label={ENTITY_CONFIG.schools.label}
@@ -274,7 +274,7 @@ export default function Dashboard() {
                             sparklineFill={ENTITY_CONFIG.schools.colorMuted}
                             percentChange={percentChanges?.schools ?? undefined}
                             showTrend={true}
-                            href="/chart?measuredAs=total-school-count"
+                            href="/chart?measuredAs=total-school-count&type=line"
                         />
                         {/* TODO: Once we store type of school, make this correct */}
                     </div>


### PR DESCRIPTION
Bug: clicking line charts in overview page links to bar charts when clicked on #226

## Who worked on this sprint/bug?
Will

## Features Implemented
Made clicking line charts in statcards link to line charts, also added linking for the statcards in school overview pages

## Existing files modified
src/app/schools/[name]/page.tsx
src/components/Dashboard.tsx


## Testing: how did you test?
localhost


@danglorioso @shaynesidman

closes #226
