### PR TITLE
fixed linking to school profile page from heatmap

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -252,6 +252,7 @@ function HeatMapPage() {
         mapRef,
         filteredSchoolPoints,
         metric,
+        year,
         showSchools,
         showHeatmap,
         showRegions,

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -11,7 +11,8 @@
 
 "use client";
 
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
+import { useQueryState, parseAsInteger } from "nuqs";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -67,16 +68,10 @@ export default function SchoolProfilePage() {
     const params = useParams();
     const schoolName = params.name as string;
     const router = useRouter();
-    const searchParams = useSearchParams();
-    const parsedYearFromQuery = Number(searchParams.get("year"));
-    const initialYearFromQuery = Number.isFinite(parsedYearFromQuery)
-        ? parsedYearFromQuery
-        : null;
-
+    const [year, setYear] = useQueryState("year", parseAsInteger);
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
     const [prevYearData, setPrevYearData] = useState<SchoolData | null>(null);
 
-    const [year, setYear] = useState<number | null>(initialYearFromQuery);
     const [projects, setProjects] = useState<ProjectRow[]>([]);
     const [editingName, setEditingName] = useState(false);
     const [nameDraft, setNameDraft] = useState("");
@@ -88,37 +83,9 @@ export default function SchoolProfilePage() {
     const [showPrevYearWarning, setShowPrevYearWarning] = useState(true);
     const [mergeOpen, setMergeOpen] = useState(false);
 
-    const buildSchoolUrl = (slug: string, yearParam: number | null) =>
-        yearParam !== null
-            ? `/schools/${slug}?year=${yearParam}`
-            : `/schools/${slug}`;
-
     const handleYearChange = (selectedYear: number | null) => {
-        if (selectedYear === null) return;
-
         setYear(selectedYear);
-
-        const parsedQueryYear = Number(searchParams.get("year"));
-        const queryYear = Number.isFinite(parsedQueryYear)
-            ? parsedQueryYear
-            : null;
-        if (queryYear !== selectedYear) {
-            router.replace(buildSchoolUrl(schoolName, selectedYear), {
-                scroll: false,
-            });
-        }
     };
-
-    useEffect(() => {
-        const yearFromQuery = searchParams.get("year");
-        if (!yearFromQuery) return;
-
-        const parsedYear = Number(yearFromQuery);
-        if (!Number.isFinite(parsedYear)) return;
-        if (year === parsedYear) return;
-
-        setYear(parsedYear);
-    }, [searchParams, year]);
 
     useEffect(() => {
         setShowPrevYearWarning(true);
@@ -131,7 +98,11 @@ export default function SchoolProfilePage() {
                 if (r.status === 301) {
                     const data = await r.json();
                     if (data.redirectTo) {
-                        router.replace(buildSchoolUrl(data.redirectTo, year));
+                        router.replace(
+                            year !== null
+                                ? `/schools/${data.redirectTo}?year=${year}`
+                                : `/schools/${data.redirectTo}`,
+                        );
                     }
                 }
             })

--- a/src/app/schools/[name]/page.tsx
+++ b/src/app/schools/[name]/page.tsx
@@ -11,7 +11,7 @@
 
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -67,11 +67,16 @@ export default function SchoolProfilePage() {
     const params = useParams();
     const schoolName = params.name as string;
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const parsedYearFromQuery = Number(searchParams.get("year"));
+    const initialYearFromQuery = Number.isFinite(parsedYearFromQuery)
+        ? parsedYearFromQuery
+        : null;
 
     const [schoolData, setSchoolData] = useState<SchoolData | null>(null);
     const [prevYearData, setPrevYearData] = useState<SchoolData | null>(null);
 
-    const [year, setYear] = useState<number | null>(null);
+    const [year, setYear] = useState<number | null>(initialYearFromQuery);
     const [projects, setProjects] = useState<ProjectRow[]>([]);
     const [editingName, setEditingName] = useState(false);
     const [nameDraft, setNameDraft] = useState("");
@@ -82,6 +87,38 @@ export default function SchoolProfilePage() {
     const [allYearsData, setAllYearsData] = useState<SchoolData[]>([]);
     const [showPrevYearWarning, setShowPrevYearWarning] = useState(true);
     const [mergeOpen, setMergeOpen] = useState(false);
+
+    const buildSchoolUrl = (slug: string, yearParam: number | null) =>
+        yearParam !== null
+            ? `/schools/${slug}?year=${yearParam}`
+            : `/schools/${slug}`;
+
+    const handleYearChange = (selectedYear: number | null) => {
+        if (selectedYear === null) return;
+
+        setYear(selectedYear);
+
+        const parsedQueryYear = Number(searchParams.get("year"));
+        const queryYear = Number.isFinite(parsedQueryYear)
+            ? parsedQueryYear
+            : null;
+        if (queryYear !== selectedYear) {
+            router.replace(buildSchoolUrl(schoolName, selectedYear), {
+                scroll: false,
+            });
+        }
+    };
+
+    useEffect(() => {
+        const yearFromQuery = searchParams.get("year");
+        if (!yearFromQuery) return;
+
+        const parsedYear = Number(yearFromQuery);
+        if (!Number.isFinite(parsedYear)) return;
+        if (year === parsedYear) return;
+
+        setYear(parsedYear);
+    }, [searchParams, year]);
 
     useEffect(() => {
         setShowPrevYearWarning(true);
@@ -94,12 +131,12 @@ export default function SchoolProfilePage() {
                 if (r.status === 301) {
                     const data = await r.json();
                     if (data.redirectTo) {
-                        router.replace(`/schools/${data.redirectTo}`);
+                        router.replace(buildSchoolUrl(data.redirectTo, year));
                     }
                 }
             })
             .catch(() => {});
-    }, [schoolName, router]);
+    }, [schoolName, router, year]);
 
     useEffect(() => {
         if (!year) return;
@@ -138,7 +175,9 @@ export default function SchoolProfilePage() {
 
                 // If the school has been merged away, redirect to the absorbing school
                 if (responses[5]?.redirectTo) {
-                    router.replace(`/schools/${responses[5].redirectTo}`);
+                    router.replace(
+                        `/schools/${responses[5].redirectTo}/?year=${year}`,
+                    );
                     return;
                 }
 
@@ -271,11 +310,7 @@ export default function SchoolProfilePage() {
                         <div className="ml-auto flex flex-row items-center gap-2">
                             <YearDropdown
                                 selectedYear={year}
-                                onYearChange={(selectedYear) => {
-                                    if (selectedYear !== null) {
-                                        setYear(selectedYear);
-                                    }
-                                }}
+                                onYearChange={handleYearChange}
                                 showDataIndicator={true}
                                 school={schoolName}
                             />
@@ -323,11 +358,7 @@ export default function SchoolProfilePage() {
                     <div className="ml-auto flex flex-row items-center gap-2">
                         <YearDropdown
                             selectedYear={year}
-                            onYearChange={(selectedYear) => {
-                                if (selectedYear !== null) {
-                                    setYear(selectedYear);
-                                }
-                            }}
+                            onYearChange={handleYearChange}
                             showDataIndicator={true}
                             school={schoolName}
                         />

--- a/src/components/YearDropdown.tsx
+++ b/src/components/YearDropdown.tsx
@@ -121,6 +121,18 @@ export default function YearDropdown({
         setYear(selectedYear ?? null);
     }, [selectedYear]);
 
+    // Keep internal display year aligned with a controlled parent year.
+    // This prevents async year list loading from snapping UI to latest year.
+    useEffect(() => {
+        if (
+            selectedYear !== null &&
+            selectedYear !== undefined &&
+            year !== selectedYear
+        ) {
+            setYear(selectedYear);
+        }
+    }, [selectedYear, year]);
+
     const handleValueChange = (value: string) => {
         const selected = value ? Number(value) : null;
         setYear(selected);

--- a/src/hooks/useHeatmapLayers.ts
+++ b/src/hooks/useHeatmapLayers.ts
@@ -35,6 +35,7 @@ interface UseHeatmapLayersOptions {
     mapRef: React.RefObject<maplibregl.Map | null>;
     filteredSchoolPoints: GeoJSON.FeatureCollection | null;
     metric: string;
+    year: number | null;
     showSchools: boolean;
     showHeatmap: boolean;
     showRegions: boolean;
@@ -44,6 +45,7 @@ export function useHeatmapLayers({
     mapRef,
     filteredSchoolPoints,
     metric,
+    year,
     showSchools,
     showHeatmap,
     showRegions,
@@ -271,10 +273,14 @@ export function useHeatmapLayers({
                     number,
                     number,
                 ];
+
                 const { name } = feature.properties || {};
                 const value = feature.properties?.[metric] || 0;
                 const schoolSlug = standardize(name);
-                const profileUrl = `/schools/${schoolSlug}`;
+                const profileUrl =
+                    year !== null
+                        ? `/schools/${schoolSlug}?year=${year}`
+                        : `/schools/${schoolSlug}`;
 
                 const html = `
                     <div style="
@@ -508,7 +514,14 @@ export function useHeatmapLayers({
             cleanup?.();
             map.off("load", onLoad);
         };
-    }, [metric, filteredSchoolPoints, showSchools, showHeatmap, showRegions]);
+    }, [
+        metric,
+        year,
+        filteredSchoolPoints,
+        showSchools,
+        showHeatmap,
+        showRegions,
+    ]);
 
     return { closePopup };
 }


### PR DESCRIPTION
## Issue
Bug: going to a schools profile from heatmap doesnt take you to right year #229

## Who worked on this sprint/bug?
Will

<!-- List partner names -->


## Features Implemented
clicking the view profile link on a schools tooltip in the heatmap now sends you to the correct year of a schools profile page


## Existing files modified
src/app/map/page.tsx
src/app/schools/[name]/page.tsx
src/components/YearDropdown.tsx
src/hooks/useHeatmapLayers.ts

## Testing: how did you test?
localhost


Notes: had to change the year dropdown component so that it can properly keep track of the current year, and changed the url of the schools profile pages. I don't think there will be any unintended side effects


@danglorioso @shaynesidman

closes #229