### PR TITLE
Fix heatmap colors, region borders, and school icons

### DIFF
--- a/src/hooks/useHeatmapLayers.ts
+++ b/src/hooks/useHeatmapLayers.ts
@@ -118,9 +118,9 @@ export function useHeatmapLayers({
                     type: "line",
                     source: "regions-source",
                     paint: {
-                        "line-color": "#FF0000",
-                        "line-width": 4,
-                        "line-opacity": 0.5,
+                        "line-color": "#475569",
+                        "line-width": 2,
+                        "line-opacity": 0.6,
                     },
                 });
             } else {
@@ -196,17 +196,17 @@ export function useHeatmapLayers({
                             ["linear"],
                             ["heatmap-density"],
                             0,
-                            "rgba(33,102,172,0)",
+                            "rgba(255,255,204,0)",
                             0.2,
-                            "rgb(103,169,207)",
+                            "rgb(255,237,160)",
                             0.4,
-                            "rgb(209,229,240)",
+                            "rgb(254,178,76)",
                             0.6,
-                            "rgb(253,219,199)",
+                            "rgb(253,141,60)",
                             0.8,
-                            "rgb(239,138,98)",
+                            "rgb(227,74,51)",
                             1,
-                            "rgb(178,24,43)",
+                            "rgb(175,39,47)",
                         ],
                         "heatmap-radius": [
                             "interpolate",
@@ -221,34 +221,20 @@ export function useHeatmapLayers({
                 });
             }
 
-            // School icon points
-            const addSchoolIcons = () => {
-                if (!showSchools) return;
-                if (!map.getLayer("school-icons")) {
-                    map.addLayer({
-                        id: "school-icons",
-                        type: "symbol",
-                        source: "schoolSource",
-                        layout: {
-                            "icon-image": "school-icon",
-                            "icon-size": 1,
-                            "icon-allow-overlap": true,
-                        },
-                    });
-                }
-            };
-
-            if (map.hasImage("school-icon")) {
-                addSchoolIcons();
-            } else {
-                const img = new Image(26, 26);
-                img.onload = () => {
-                    if (!map.hasImage("school-icon")) {
-                        map.addImage("school-icon", img);
-                    }
-                    addSchoolIcons();
-                };
-                img.src = "/images/school-heatmap-icon.svg";
+            // School dot points
+            if (showSchools && !map.getLayer("school-icons")) {
+                map.addLayer({
+                    id: "school-icons",
+                    type: "circle",
+                    source: "schoolSource",
+                    paint: {
+                        "circle-radius": 5,
+                        "circle-color": "#1e293b",
+                        "circle-stroke-width": 1.5,
+                        "circle-stroke-color": "#ffffff",
+                        "circle-opacity": 0.85,
+                    },
+                });
             }
 
             // Toggle layer visibility


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

#235 Design: Heatmap Colors

## Who worked on this sprint/bug?

Cloud Agent (Cursor)

## Who did what on this sprint/bug?

All changes implemented together as a single cohesive visual improvement to the heatmap page.

## Features Implemented

- **Improved heatmap color ramp**: Replaced the old blue-to-red diverging palette with a warm sequential YlOrRd gradient (transparent → warm yellow → orange → MHD brand red `#af272f`). This provides better visual clarity and consistency with the MHD brand.
- **Subtler region boundary lines**: Changed from harsh red (`#FF0000`, width 4) to a subtle slate gray (`#475569`, width 2, 60% opacity) so region borders guide the eye without overpowering the data.
- **Clean school dot markers**: Replaced the complex 26×26 school building SVG icon (loaded as a symbol layer) with a native MapLibre circle layer — a small dark slate dot (`#1e293b`) with a white stroke. This is cleaner, renders crisply at all zoom levels, and removes the image-loading step entirely.

## New files created

None

## Existing files modified

- `src/hooks/useHeatmapLayers.ts` — all three visual changes

## Acceptance Criteria

- [x] Heatmap colors are improved (warm gradient instead of blue-red diverging)
- [x] Region borders are toned down (no longer harsh red)
- [x] School icons are replaced with clean small dots

## Testing: how did you test?

- TypeScript type check (`tsc --noEmit`) — no new errors
- ESLint (`npm run lint`) — passes clean
- Verified all popup/tooltip interactions still reference the same `school-icons` layer ID, which works identically for circle layers as it did for symbol layers

## Features Not Implemented/Incomplete

None

## Bugs Discovered

- Pre-existing: `src/lib/pdf-layout.ts` has TS errors for PNG module imports (unrelated to this PR)

## Screenshots:

Visual changes — heatmap now uses a warm yellow-orange-red palette, region lines are subtle gray, and school markers are clean small dots.

## Tag Dan and Shayne

@danglorioso @shaynesidman
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed59de4d-d418-407a-a7d1-2f3a2732fdef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed59de4d-d418-407a-a7d1-2f3a2732fdef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

